### PR TITLE
Fix for wrong language selected if MPEG audio is not available, but AC3 is available.

### DIFF
--- a/TvEngine3/TVLibrary/TvPlugin/TvPlugin/TVHome.cs
+++ b/TvEngine3/TVLibrary/TvPlugin/TvPlugin/TVHome.cs
@@ -2693,6 +2693,7 @@ namespace TvPlugin
       int idxStreamIndexAc3 = -1; // the streamindex of ac3 found based on lang. pref
       int idxStreamIndexmpeg = -1; // the streamindex of mpg found based on lang. pref   
       int idx = -1; // the chosen audio index we return
+      int idxAC3 = -1;
       int idxLangPriAc3 = -1; // the lang priority of ac3 found based on lang. pref
       int idxLangPrimpeg = -1; // the lang priority of mpg found based on lang. pref         
       string ac3BasedOnLang = ""; // for debugging, what lang. in prefs. where used to choose the ac3 audio track ?
@@ -2731,14 +2732,16 @@ namespace TvPlugin
       UpdateAudioStreamIndexesAndPrioritiesBasedOnLanguage(streams, priority, ref idxStreamIndexmpeg,
                                                            ref mpegBasedOnLang, ref idxStreamIndexAc3, idxLangPriAc3,
                                                            idxLangPrimpeg, ref ac3BasedOnLang, out dualMonoMode);
-      idx = GetAC3AudioStreamIndex(idxStreamIndexmpeg, idxStreamIndexAc3, ac3BasedOnLang, idx, idxFirstAc3);
+      idx = -1;
+      idxAC3 = GetAC3AudioStreamIndex(idxStreamIndexmpeg, idxStreamIndexAc3, ac3BasedOnLang, idx, idxFirstAc3);
+      Log.Debug("Audio stream: AC3 index {0}", idxAC3);
 
-      if (idx == -1 && _preferAC3)
+      if (idxAC3 == -1 && _preferAC3)
       {
         Log.Info("Audio stream: no preferred AC3 audio stream found, trying mpeg instead.");
       }
 
-      if (idx == -1 || !_preferAC3)
+      if (idxAC3 == -1 || !_preferAC3)
       // we end up here if ac3 selection didnt happen (no ac3 avail.) or if preferac3 is disabled.
       {
         if (IsPreferredAudioLanguageAvailable())
@@ -2756,8 +2759,16 @@ namespace TvPlugin
 
       if (idx == -1)
       {
-        idx = 0;
-        Log.Info("Audio stream: no preferred stream found - switching to audio stream 0");
+          if (idxAC3 == -1)
+          {
+              idx = 0;
+              Log.Info("Audio stream: no preferred stream found - switching to audio stream 0");
+          }
+          else
+          {
+              Log.Info("Audio stream: No preferred MPEG stream found, switching to AC3 stream {0}", idxAC3);
+              idx = idxAC3;
+          }
       }
 
       return idx;
@@ -2766,7 +2777,7 @@ namespace TvPlugin
     private static int GetAC3AudioStreamIndex(int idxStreamIndexmpeg, int idxStreamIndexAc3, string ac3BasedOnLang,
                                               int idx, int idxFirstAc3)
     {
-      if (_preferAC3)
+      //if (_preferAC3)
       {
         if (IsPreferredAudioLanguageAvailable())
         {


### PR DESCRIPTION
See discussion at http://forum.team-mediaportal.com/submit-code-patches-mediaportal-tv-server-etc-325/patch-ac3-lang-select-when-no-mpeg-audio-105178/

If PreferAC3 is false and no MPEG audio streams are available, TVPlugin switch to the first AC3 stream regardless of language preferences. 
Before the patch MP checks the audio streams in the following order if PreferAC3 is false:

1. select MPEG stream based on language pref
2. if not found then select MPEG stream index 0.
3. if no MPEG stream is found then select audio stream index 0.

With the patch MP checks the streams in the following order if PreferAC3 is false:

1. select MPEG stream based on language pref
2. if not found then select MPEG stream index 0.
3. if no MPEG stream is found then select AC3 stream based on language pref
4. If not found then select audio stream index 0.