### PR TITLE
WebEPG - Patch for the ability to replace

### DIFF
--- a/TvEngine3/TVLibrary/TvLibrary.Utils/Web/Parser/HtmlParser.cs
+++ b/TvEngine3/TVLibrary/TvLibrary.Utils/Web/Parser/HtmlParser.cs
@@ -98,7 +98,8 @@ namespace MediaPortal.Utils.Web
       int count = 0;
       if (pageSource != null)
       {
-        count = _profiler.MatchCount(pageSource.Substring(startIndex, endIndex - startIndex));
+          //run the replacement tasks before parsing the page source
+          count = _profiler.MatchCount(Replacements(pageSource.Substring(startIndex, endIndex - startIndex)));
       }
 
       return count;
@@ -163,7 +164,6 @@ namespace MediaPortal.Utils.Web
         sectionSource = _profiler.GetSource(index);
       }
 
-
       Match result = null;
       try
       {
@@ -196,7 +196,6 @@ namespace MediaPortal.Utils.Web
           _sectionSource += sectionSource.Substring(end, sectionSource.Length - end);
         }
       }
-
       return found;
     }
 
@@ -307,6 +306,68 @@ namespace MediaPortal.Utils.Web
     #endregion
 
     #region Private Methods
+
+    /// <summary>
+    /// Goes through all the replacement tasks and does the replacement each time on the modified page.
+    /// The result page will be retuned.
+    /// </summary>
+    /// <param name="pageSource">Source of the page as string</param>
+    /// <returns>Modified (replace) pageSource</returns>
+    private string Replacements(string pageSource)
+    {
+        string page = string.Empty;
+        if (pageSource == string.Empty || pageSource == null)
+        {
+            return string.Empty;
+        }
+        else
+        {
+            page = pageSource;
+        }
+
+        foreach (HtmlReplaceData replaceTask in _template.replaceList)
+        {
+            if (replaceTask.Match == null || replaceTask.Replace == null)
+            {
+                continue;
+            }
+            page = ReplaceRegex(page, replaceTask.Match, replaceTask.Replace);
+        }
+
+        return page;
+    }
+
+    /// <summary>
+    /// Does the replacements to the text by regex. The result text will be returned.
+    /// </summary>
+    /// <param name="text">Some text as string</param>
+    /// <param name="regexMatch">text or regex to replace</param>
+    /// <param name="replaceText">string for replacement</param>
+    /// <returns>Modified (replaced) text</returns>
+    private string ReplaceRegex(string text, string regexMatch, string replaceText)
+    {
+        if (text == string.Empty)
+        {
+            return string.Empty;
+        }
+        if (regexMatch == string.Empty)
+        {
+            return text;   
+        }
+
+        string result = null;
+        try
+        {
+            Regex searchRegex = new Regex(regexMatch);
+            result = searchRegex.Replace(text, replaceText);
+        }
+        catch (ArgumentException)
+        {
+            return string.Empty;
+        }
+
+        return result;
+    }
 
     /// <summary>
     /// Gets the java sub link params.

--- a/TvEngine3/TVLibrary/TvLibrary.Utils/Web/Parser/HtmlParserTemplate.cs
+++ b/TvEngine3/TVLibrary/TvLibrary.Utils/Web/Parser/HtmlParserTemplate.cs
@@ -20,6 +20,7 @@
 
 using System;
 using System.Xml.Serialization;
+using System.Collections.Generic;
 
 namespace MediaPortal.Utils.Web
 {
@@ -34,6 +35,7 @@ namespace MediaPortal.Utils.Web
     [XmlAttribute("name")] public string Name;
     [XmlAttribute("start")] public string Start;
     [XmlAttribute("end")] public string End;
+    [XmlArray("Replaces")] [XmlArrayItem("Replace")] public List<HtmlReplaceData> replaceList; //list with replace tasks
     [XmlElement("SectionTemplate")] public HtmlSectionTemplate SectionTemplate;
 
     #endregion

--- a/TvEngine3/TVLibrary/TvLibrary.Utils/Web/Parser/HtmlReplaceData.cs
+++ b/TvEngine3/TVLibrary/TvLibrary.Utils/Web/Parser/HtmlReplaceData.cs
@@ -1,0 +1,37 @@
+#region Copyright (C) 2005-2011 Team MediaPortal
+
+// Copyright (C) 2005-2011 Team MediaPortal
+// http://www.team-mediaportal.com
+// 
+// MediaPortal is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 2 of the License, or
+// (at your option) any later version.
+// 
+// MediaPortal is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with MediaPortal. If not, see <http://www.gnu.org/licenses/>.
+
+#endregion
+
+using System.Xml.Serialization;
+
+namespace MediaPortal.Utils.Web
+{
+  /// <summary>
+  /// Replace task data
+  /// </summary>
+  public class HtmlReplaceData
+  {
+    #region Variables
+
+    [XmlAttribute("match")] public string Match; //text or regex to be replaced
+    [XmlAttribute("replace")] public string Replace; //text to replace
+
+    #endregion
+  }
+}


### PR DESCRIPTION
## Forum Thread: ##
http://forum.team-mediaportal.com/threads/webepg-patch-for-the-ability-to-replace.106801/

## Summary: ##
This patch adds a regex replace function to the html parser (indirect to webepg). The regex replace functions will be done on the page source.

## Problem: ##
There are situations, where a template don't match to the whole grabbing page because of some inconsistency on this page. The template goes through the page source and does the work till the inconsistency comes. After this template doesn't much anymore and ignores the rest of this page.
Inconsistency example:
### page source: ###
<pre><code>
...
&lt;div&gt;Time&lt;/div&gt;&lt;div&gt;ProgramName&lt;/div&gt;
&lt;div&gt;Time&lt;/div&gt;&lt;div&gt;ProgramName&lt;/div&gt;
&lt;div&gt;Time&lt;/div&gt;&lt;div&gt;ProgramName&lt;/div&gt;&lt;div&gt;Inconsistency&lt;/div&gt;
&lt;div&gt;Time&lt;/div&gt;&lt;div&gt;ProgramName&lt;/div&gt;
…
</code></pre>
### template: ###
<pre><code>
&lt;div&gt;#TIME&lt;/div&gt;&lt;div&gt;#NAME&lt;/div&gt;
</code></pre>

### result: ###
1. #TIME:Time; #NAME:ProgramName
2. #TIME:Time; #NAME:ProgramName
3. #TIME:Time; #NAME:ProgramName
4. #TIME:Inconsistency; #NAME:Time  ⇒ Error

## Solution: ##
A solution for this problem is to replace/remove this inconsistency before parsing the page (send the page to the template parser).
Since there has been no way for it, I have implemented it myself.

## Solution example: ##
### page source: ###
<pre><code>
...
&lt;div&gt;Time&lt;/div&gt;&lt;div&gt;ProgramName&lt;/div&gt;
&lt;div&gt;Time&lt;/div&gt;&lt;div&gt;ProgramName&lt;/div&gt;
&lt;div&gt;Time&lt;/div&gt;&lt;div&gt;ProgramName&lt;/div&gt;&lt;div&gt;Inconsistency&lt;/div&gt;
&lt;div&gt;Time&lt;/div&gt;&lt;div&gt;ProgramName&lt;/div&gt;
…
</code></pre>
### template: ###
<pre><code>
&lt;div&gt;#TIME&lt;/div&gt;&lt;div&gt;#NAME&lt;/div&gt;
</code></pre>

### replace: ###
<pre><code>
&lt;replace match=”&lt;div&gt;Inconsistency&lt;/div&gt;” replace=”” /&gt;
</code></pre>

### page source before parsing: ###
<pre><code>
...
&lt;div&gt;Time&lt;/div&gt;&lt;div&gt;ProgramName&lt;/div&gt;
&lt;div&gt;Time&lt;/div&gt;&lt;div&gt;ProgramName&lt;/div&gt;
&lt;div&gt;Time&lt;/div&gt;&lt;div&gt;ProgramName&lt;/div&gt;
&lt;div&gt;Time&lt;/div&gt;&lt;div&gt;ProgramName&lt;/div&gt;
…
</code></pre>
### result: ###
1. #TIME:Time; #NAME:ProgramName
2. #TIME:Time; #NAME:ProgramName
3. #TIME:Time; #NAME:ProgramName
4. #TIME:Time; #NAME:ProgramName

## How this works: ##
Now you can add the following new tags to your grabber file.
<pre><code>
&lt;replaces&gt;
    &lt;replace match=”” replace=”” /&gt;
    &lt;replace match=”” replace=”” /&gt;
    ...
&lt;/replaces&gt;
</code></pre>
### Legends: ###
match: The part you want to replace. (Uses RegExp)
replace: The text you want to replace with. (no RegExp)

1. The replace function will do all the replace tasks in the order you write them in your file, from up to down.
2. This replacements will be done before the template parsing, but after the page was cut (template-start, template-end). So the replacement affects only the important part of the page.
3. Because of point 2 and because of the actual structure of “htmlparser” and “webepg” code, the replaces-tags must be placed inside the template-tag.
<pre><code>&lt;template&gt;
   &lt;replaces&gt;
       …
   &lt;/replaces&gt;
&lt;/template&gt;
</code></pre>

I hope you would add this code to git, and we can see that in the next MediaPortal release 1.2.3