### PR TITLE
patch-1 - Fix Genpix BDA diseqc functionailty

### DIFF
--- a/TvEngine3/TVLibrary/TVLibrary/Implementations/DVB/DisEqC/Genpix.cs
+++ b/TvEngine3/TVLibrary/TVLibrary/Implementations/DVB/DisEqC/Genpix.cs
@@ -388,7 +388,7 @@ namespace TvLibrary.Implementations.DVB
       }
 
       BdaExtensionParams message = new BdaExtensionParams();
-      message.DiseqcMessageLength = 0;
+      message.DiseqcMessageLength = (uint)command.Length;
       message.DiseqcRepeats = 0;
       message.DiseqcForceHighVoltage = false;
       message.DiseqcMessage = new byte[MaxDiseqcMessageLength];


### PR DESCRIPTION
Update Genpix Branch to fix bug in Custom DiSEqC by mm1352000

Message length was incorrectly set to zero in SendDiSEqCCommand function causing all DiSEqC requests to be treated as tone bursts (resulting in DiSEqC commands not working). 

Motor functionality now working (tested with Skywalker-1 on genpix BDA driver 0.1.0.4 with SG-2100)
