### PR TITLE
PowerScheduler: Do not poll at one second intervals

### DIFF
--- a/TvEngine3/TVLibrary/Plugins/PowerScheduler/PowerScheduler.cs
+++ b/TvEngine3/TVLibrary/Plugins/PowerScheduler/PowerScheduler.cs
@@ -825,32 +825,29 @@ namespace TvEngine.PowerScheduler
         Log.Error("Powerscheduler: Error naming thread - {0}", ex.Message);
       }
 
-      int reload = 0;
+      LogVerbose("Looping in intervals of {0} seconds", PowerSettings.CheckInterval);
+
       do
       {
         if (!_standby)
         {
           try
           {
-            if (reload++ == _reloadInterval)
-            {
-              reload = 0;
-              CheckForStandby(true);
-              // Clear cache
-              CacheManager.Clear();
-              GC.Collect();
-              LoadSettings();
-              SendPowerSchedulerEvent(PowerSchedulerEventType.Elapsed);
-            }
-            else
-              CheckForStandby(false);
+            CheckForStandby(true);
+
+            // Clear cache
+            CacheManager.Clear();
+            GC.Collect();
+            LoadSettings();
+
+            SendPowerSchedulerEvent(PowerSchedulerEventType.Elapsed);
           }
           catch (Exception ex)
           {
             Log.Write(ex);
           }
         }
-        if (_stopThread.WaitOne(1000)) // Wait one sec / exit
+        if (_stopThread.WaitOne(PowerSettings.CheckInterval * 1000)) // Wait one sec / exit
         {
           LogVerbose("Powerscheduler poll thread - exit");
           return;


### PR DESCRIPTION
Currently the PowerScheduler always polls at one-second intervals, instead of the user configured time. This is a totally unnecessary load on the system, and causes performance problems when using PowerScheduler plugins that need a bit more CPU.

See also this thread on the forums: http://forum.team-mediaportal.com/threads/powerscheduler-unconditionally-checks-every-second.101689/
