### PR TITLE
Updated DVB-C tuning details for Ziggo (5555)/The Netherlands

### DIFF
--- a/TvEngine3/TVLibrary/TVServer.Base/TuningParameters/dvbc/The Netherlands.Ziggo NID 5555.xml
+++ b/TvEngine3/TVLibrary/TVServer.Base/TuningParameters/dvbc/The Netherlands.Ziggo NID 5555.xml
@@ -7,17 +7,17 @@
   </DVBCTuning>
   <DVBCTuning>
     <Frequency>340000</Frequency>
-    <ModulationType>Mod64Qam</ModulationType>
+    <ModulationType>Mod256Qam</ModulationType>
     <SymbolRate>6875</SymbolRate>
   </DVBCTuning>
   <DVBCTuning>
     <Frequency>348000</Frequency>
-    <ModulationType>Mod64Qam</ModulationType>
+    <ModulationType>Mod256Qam</ModulationType>
     <SymbolRate>6875</SymbolRate>
   </DVBCTuning>
   <DVBCTuning>
     <Frequency>356000</Frequency>
-    <ModulationType>Mod64Qam</ModulationType>
+    <ModulationType>Mod256Qam</ModulationType>
     <SymbolRate>6875</SymbolRate>
   </DVBCTuning>
   <DVBCTuning>


### PR DESCRIPTION
Modulation changed for transponder 2,3 and 4 from 64 to 256 QAM.
