### PR TITLE
Fix TvServer version comparison in MPEI (min and max were reversed)

### DIFF
--- a/mediaportal/MPE/MpeCore/Classes/VersionInfo.cs
+++ b/mediaportal/MPE/MpeCore/Classes/VersionInfo.cs
@@ -136,22 +136,50 @@ namespace MpeCore.Classes
 
     private static int CompareNumber(string s1, string s2)
     {
-      if (s1 == "*")
-        return 0;
-      if (s2 == "*")
+      if (s1 == "*" || s2 == "*")
         return 0;
       int i = s1.CompareTo(s2);
       int v1 = -1;
       int v2 = -1;
-      try
+
+      if (int.TryParse(s1, out v1) && int.TryParse(s2, out v2))
       {
-        int.TryParse(s1, out v1);
-        int.TryParse(s2, out v2);
-      }
-      catch (Exception) {}
-      if (v1 > -1 && v2 > -1)
         return v1.CompareTo(v2);
-      return s1.CompareTo(s2);
+      }
+      else
+      {
+        return s1.CompareTo(s2);
+      }
+    }
+
+    public static bool operator ==(VersionInfo v1, VersionInfo v2)
+    {
+      return v1.CompareTo(v2) == 0;
+    }
+
+    public static bool operator !=(VersionInfo v1, VersionInfo v2)
+    {
+      return v1.CompareTo(v2) != 0;
+    }
+
+    public static bool operator <=(VersionInfo v1, VersionInfo v2)
+    {
+      return v1.CompareTo(v2) <= 0;
+    }
+
+    public static bool operator >=(VersionInfo v1, VersionInfo v2)
+    {
+      return v1.CompareTo(v2) >= 0;
+    }
+
+    public static bool operator <(VersionInfo v1, VersionInfo v2)
+    {
+      return v1.CompareTo(v2) < 0;
+    }
+
+    public static bool operator >(VersionInfo v1, VersionInfo v2)
+    {
+      return v1.CompareTo(v2) > 0;
     }
   }
 }

--- a/mediaportal/MPE/MpeCore/Classes/VersionProvider/ExtensionVersion.cs
+++ b/mediaportal/MPE/MpeCore/Classes/VersionProvider/ExtensionVersion.cs
@@ -24,22 +24,14 @@ using MpeCore.Interfaces;
 
 namespace MpeCore.Classes.VersionProvider
 {
-  public class ExtensionVersion : IVersionProvider
+  public class ExtensionVersion : VersionProvider
   {
-    public string DisplayName
+    public override string DisplayName
     {
       get { return "Extension"; }
     }
 
-    public bool Validate(DependencyItem componentItem)
-    {
-      if (componentItem.MinVersion.CompareTo(Version(componentItem.Id)) <= 0 &&
-          componentItem.MaxVersion.CompareTo(Version(componentItem.Id)) >= 0)
-        return true;
-      return false;
-    }
-
-    public VersionInfo Version(string id)
+    public override VersionInfo Version(string id)
     {
       PackageClass pak = MpeInstaller.InstalledExtensions.Get(id);
       if (pak != null)

--- a/mediaportal/MPE/MpeCore/Classes/VersionProvider/InstallerVersion.cs
+++ b/mediaportal/MPE/MpeCore/Classes/VersionProvider/InstallerVersion.cs
@@ -24,22 +24,14 @@ using MpeCore.Interfaces;
 
 namespace MpeCore.Classes.VersionProvider
 {
-  public class InstallerVersion : IVersionProvider
+  public class InstallerVersion : VersionProvider
   {
-    public string DisplayName
+    public override string DisplayName
     {
       get { return "Installer"; }
     }
 
-    public bool Validate(DependencyItem componentItem)
-    {
-      if (Version(componentItem.Id).CompareTo(componentItem.MinVersion) >= 0 &&
-          Version(componentItem.Id).CompareTo(componentItem.MaxVersion) <= 0)
-        return true;
-      return false;
-    }
-
-    public VersionInfo Version(string id)
+    public override VersionInfo Version(string id)
     {
       return new VersionInfo(typeof(InstallerVersion).Assembly.GetName().Version);
     }

--- a/mediaportal/MPE/MpeCore/Classes/VersionProvider/MediaPortalVersion.cs
+++ b/mediaportal/MPE/MpeCore/Classes/VersionProvider/MediaPortalVersion.cs
@@ -27,26 +27,24 @@ using MpeCore.Classes;
 
 namespace MpeCore.Classes.VersionProvider
 {
-  public class MediaPortalVersion : IVersionProvider
+  public class MediaPortalVersion : VersionProvider
   {
     public static readonly VersionInfo MinimumMPVersionRequired = new VersionInfo(MediaPortal.Common.Utils.CompatibilityManager.GetCurrentVersion());
     
-    public string DisplayName
+    public override string DisplayName
     {
       get { return "MediaPortal"; }
     }
 
-    public bool Validate(DependencyItem componentItem)
+    public override bool Validate(DependencyItem dependency)
     {
-      if (componentItem.MinVersion.CompareTo(MinimumMPVersionRequired) < 0)
+      if (dependency.MinVersion < MinimumMPVersionRequired)
         return false;
-      if (Version(componentItem.Id).CompareTo(componentItem.MinVersion) >= 0 &&
-          Version(componentItem.Id).CompareTo(componentItem.MaxVersion) <= 0)
-        return true;
-      return false;
+
+      return base.Validate(dependency);
     }
 
-    public VersionInfo Version(string id)
+    public override VersionInfo Version(string id)
     {
       return new VersionInfo(MediaPortal.Common.Utils.CompatibilityManager.GetCurrentVersion());
     }

--- a/mediaportal/MPE/MpeCore/Classes/VersionProvider/SkinVersion.cs
+++ b/mediaportal/MPE/MpeCore/Classes/VersionProvider/SkinVersion.cs
@@ -6,22 +6,14 @@ using MpeCore.Interfaces;
 
 namespace MpeCore.Classes.VersionProvider
 {
-  public class SkinVersion : IVersionProvider
+  public class SkinVersion : VersionProvider
   {
-    public string DisplayName
+    public override string DisplayName
     {
       get { return "Skin"; }
     }
 
-    public bool Validate(DependencyItem componentItem)
-    {
-      if (componentItem.MinVersion.CompareTo(Version(componentItem.Id)) <= 0 &&
-          componentItem.MaxVersion.CompareTo(Version(componentItem.Id)) >= 0)
-        return true;
-      return false;
-    }
-
-    public VersionInfo Version(string id)
+    public override VersionInfo Version(string id)
     {
       return new VersionInfo(MediaPortal.Common.Utils.CompatibilityManager.SkinVersion);
     }

--- a/mediaportal/MPE/MpeCore/Classes/VersionProvider/TvServerVersion.cs
+++ b/mediaportal/MPE/MpeCore/Classes/VersionProvider/TvServerVersion.cs
@@ -23,22 +23,14 @@ using MpeCore.Interfaces;
 
 namespace MpeCore.Classes.VersionProvider
 {
-  public class TvServerVersion : IVersionProvider
+  public class TvServerVersion : VersionProvider
   {
-    public string DisplayName
+    public override string DisplayName
     {
       get { return "TvServer"; }
     }
 
-    public bool Validate(DependencyItem componentItem)
-    {
-      if (componentItem.MinVersion.CompareTo(Version(componentItem.Id)) >= 0 &&
-          componentItem.MaxVersion.CompareTo(Version(componentItem.Id)) <= 0)
-        return true;
-      return false;
-    }
-
-    public VersionInfo Version(string id)
+    public override VersionInfo Version(string id)
     {
       RegistryKey key =
         Registry.LocalMachine.OpenSubKey(

--- a/mediaportal/MPE/MpeCore/Classes/VersionProvider/VersionProvider.cs
+++ b/mediaportal/MPE/MpeCore/Classes/VersionProvider/VersionProvider.cs
@@ -1,0 +1,21 @@
+﻿using MpeCore.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MpeCore.Classes.VersionProvider
+{
+  public abstract class VersionProvider : IVersionProvider
+  {
+    public virtual bool Validate(DependencyItem dependency)
+    {
+      var version = Version(dependency.Id);
+      return (version >= dependency.MinVersion && version <= dependency.MaxVersion);
+    }
+
+    public abstract string DisplayName { get; }
+
+    public abstract VersionInfo Version(string id);
+  }
+}

--- a/mediaportal/MPE/MpeCore/MpeCore.csproj
+++ b/mediaportal/MPE/MpeCore/MpeCore.csproj
@@ -214,6 +214,7 @@
     <Compile Include="Classes\VersionProvider\MediaPortalVersion.cs" />
     <Compile Include="Classes\VersionProvider\SkinVersion.cs" />
     <Compile Include="Classes\VersionProvider\TvServerVersion.cs" />
+    <Compile Include="Classes\VersionProvider\VersionProvider.cs" />
     <Compile Include="Classes\WizardButtonsEnum.cs" />
     <Compile Include="Classes\WizardNavigator.cs" />
     <Compile Include="Classes\ZipProvider\ZipProviderClass.cs" />


### PR DESCRIPTION
The version comparison for TvServer had the min and max conversion
reversed.  I think this was partly due to the CompareTo function making
the code cryptic to read.  Refactored all the version comparison code
into the new VersionInfo abstract class and implemented operator
comparisons.
