### PR TITLE
Allow other plugins reading the next PS wakeup time

### DIFF
--- a/Common-MP-TVE3/PowerScheduler.Interfaces/WaitableTimer.cs
+++ b/Common-MP-TVE3/PowerScheduler.Interfaces/WaitableTimer.cs
@@ -185,6 +185,11 @@ namespace TvEngine.PowerScheduler
           CancelWaitableTimer(SafeWaitHandle);
         }
       }
+      get
+      {
+        // Return expiration time
+        return DateTime.FromFileTimeUtc(m_ExpirationTime).ToLocalTime();
+      }
     }
 
     /// <summary>

--- a/TvEngine3/TVLibrary/Plugins/PowerScheduler/PowerScheduler.cs
+++ b/TvEngine3/TVLibrary/Plugins/PowerScheduler/PowerScheduler.cs
@@ -1011,6 +1011,14 @@ namespace TvEngine.PowerScheduler
       }
     }
 
+    /// <summary>
+    /// Returns the next wakeup time from the PowerScheduler plugin
+    /// </summary>
+    public DateTime GetTimeToWakeup()
+    {
+      return _wakeupTimer.TimeToWakeup;
+    }
+
     #endregion
 
     #region Private methods


### PR DESCRIPTION
Having the ability to do so my USB device would be able to wake the PC at the according time. By connecting the device to the PCs power button it can even wake from S5.

Device schematics and firmware sources will follow.

For a detailed feature list see http://forum.team-mediaportal.com/threads/is-there-any-use-for-a-multi-protocol-ir-receiver-transmitter.129216/
