### PR TITLE
MP1-4750: HID mute, volume and TV power/MP Exit fixes.

### DIFF
--- a/mediaportal/MPTray/MPTray.csproj
+++ b/mediaportal/MPTray/MPTray.csproj
@@ -41,7 +41,7 @@
   <ItemGroup>
     <Reference Include="SharpLibHid, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\Packages\SharpLibHid.1.3.0\lib\net20\SharpLibHid.dll</HintPath>
+      <HintPath>..\..\Packages\SharpLibHid.1.3.1\lib\net20\SharpLibHid.dll</HintPath>
     </Reference>
     <Reference Include="SharpLibWin32, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>

--- a/mediaportal/MPTray/packages.config
+++ b/mediaportal/MPTray/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SharpLibHid" version="1.3.0" targetFramework="net40" />
+  <package id="SharpLibHid" version="1.3.1" targetFramework="net40" />
   <package id="SharpLibWin32" version="0.0.7" targetFramework="net40" />
 </packages>

--- a/mediaportal/MediaPortal.Base/defaults/InputDeviceMappings/Generic-HID.xml
+++ b/mediaportal/MediaPortal.Base/defaults/InputDeviceMappings/Generic-HID.xml
@@ -6,33 +6,54 @@
       <action layer="0" condition="*" conproperty="-1" command="ACTION" cmdproperty="10" sound="back.wav" />
     </button>
 
+    <!-- Place holders so that they show up in the configure mapping customization UI -->
     <button code="AppCtrlForward" />
     <button code="AppCtrlRefresh" />
     <button code="AppCtrlStop" />
     <button code="AppCtrlSearch" />
     <button code="AppCtrlBookmarks" />
     <button code="AppCtrlHome" />
+    <button code="AppCtrlFind" />
+    <button code="AppCtrlNew" />
+    <button code="AppCtrlOpen" />
+    <button code="AppCtrlClose" />
+    <button code="AppCtrlSave" />
+    <button code="AppCtrlUndo" />
+    <button code="AppCtrlCopy" />
+    <button code="AppCtrlCut" />
+    <button code="AppCtrlPaste" />
+    <button code="AppCtrlRedoRepeat" />
+    <button code="AppCtrlForwardMsg" />
+    <button code="AppCtrlSend" />
+    <button code="AppCtrlReply" />
+    <button code="AppLaunchEmailReader" />
+    <button code="AppLaunchSpellCheck" />
+    <button code="BassIncrement" />
+    <button code="BassDecrement" />
+    <button code="TrebleIncrement" />
+    <button code="TrebleDecrement" />
+    <button code="BassBoost" />
+    <button code="Help" />
+    <!-- Let the OS deal with volume control-->
+    <button code="Mute" />
+    <button code="VolumeDecrement" />
+    <button code="VolumeIncrement" />
+    
+    <!-- Define exit commands -->
+    <button code="AppCtrlExit">
+      <action layer="0" condition="*" conproperty="-1" command="POWER" cmdproperty="EXIT" sound="back.wav" />
+    </button>
 
+    <!-- Define actions for our "More Info" button, alternatively showing as "i", "Info" or "Menu" on some remotes -->
     <button code="AppCtrlProperties">
       <action layer="0" condition="FULLSCREEN" conproperty="TRUE" command="ACTION" cmdproperty="24" sound="click.wav" />
       <action layer="0" condition="*" conproperty="-1" command="ACTION" cmdproperty="106" sound="click.wav" />
     </button>
 
+    <!-- Define actions for our "Guide" button (EPG) -->
     <button code="MediaSelectProgramGuide">
       <action layer="0" condition="WINDOW" conproperty="600" command="ACTION" cmdproperty="10" sound="back.wav" />
       <action layer="0" condition="*" conproperty="-1" command="WINDOW" cmdproperty="600" sound="click.wav" />
-    </button>
-
-    <button code="Mute" background="true">
-      <action layer="0" condition="*" conproperty="-1" command="ACTION" cmdproperty="9982" sound="click.wav" />
-    </button>
-
-    <button code="VolumeDecrement" background="true" repeat="true">
-      <action layer="0" condition="*" conproperty="-1" command="ACTION" cmdproperty="102" sound="cursor.wav" />
-    </button>
-
-    <button code="VolumeIncrement" background="true" repeat="true">
-      <action layer="0" condition="*" conproperty="-1" command="ACTION" cmdproperty="103" sound="cursor.wav" />
     </button>
 
     <button code="Play" background="true" >
@@ -49,7 +70,6 @@
       <action layer="0" condition="PLAYER" conproperty="MEDIA" command="ACTION" cmdproperty="12" sound="click.wav" />
       <action layer="0" condition="*" conproperty="-1" command="ACTION" cmdproperty="68" sound="click.wav" />
     </button>
-
 
     <button code="Stop" background="true">
       <action layer="0" condition="*" conproperty="-1" command="ACTION" cmdproperty="13" sound="click.wav" />
@@ -114,30 +134,7 @@
       <action layer="0" condition="*" conproperty="-1" command="ACTION" cmdproperty="19" sound="click.wav" />
     </button>
 
-
-    <button code="BassBoost" />
-    <button code="Help" />
-    <button code="AppCtrlFind" />
-    <button code="AppCtrlNew" />
-    <button code="AppCtrlOpen" />
-    <button code="AppCtrlClose" />
-    <button code="AppCtrlSave" />
-    <button code="AppCtrlUndo" />
-    <button code="AppCtrlCopy" />
-    <button code="AppCtrlCut" />
-    <button code="AppCtrlPaste" />
-    <button code="AppCtrlRedoRepeat" />
-    <button code="AppLaunchEmailReader" />
-    <button code="AppLaunchSpellCheck" />
-    <button code="AppCtrlForwardMsg" />
-    <button code="AppCtrlSend" />
-    <button code="AppCtrlReply" />
-    <button code="BassIncrement" />
-    <button code="BassDecrement" />
-    <button code="TrebleIncrement" />
-    <button code="TrebleDecrement" />
-
-    <!--
+<!--
 
     <button name="16 LaunchMediaSelect" code="16" />
     <button name="17 LaunchApp1" code="17" />
@@ -162,16 +159,19 @@
       <action layer="0" condition="*" conproperty="-1" command="WINDOW" cmdproperty="0" sound="click.wav" focus="True" />
     </button>
 
+    <!-- TV Power button closes MediaPortal, applies also if MP is not in the foreground -->
+    <button code="TvPower" background="true">
+      <action layer="0" condition="*" conproperty="-1" command="POWER" cmdproperty="EXIT" sound="back.wav" />
+    </button>
+
+    <!-- Extension 11 button closes MediaPortal too, applies also if MP is not in the foreground  -->
+    <button code="Ext11" background="true">
+      <action layer="0" condition="*" conproperty="-1" command="POWER" cmdproperty="EXIT" sound="back.wav" />
+    </button>
+
     <button code="RecordedTv">
       <action layer="0" condition="*" conproperty="-1" command="WINDOW" cmdproperty="603" sound="click.wav" />
     </button>
-
-
-    <!--
-    <button name="Power TV" code="power">
-      <action layer="0" condition="*" conproperty="-1" command="POWER" cmdproperty="EXIT" sound="back.wav" />
-    </button>
-    -->
 
     <button code="Tv">
       <action layer="0" condition="WINDOW" conproperty="7701" command="WINDOW" cmdproperty="602" sound="click.wav" />

--- a/mediaportal/RemotePlugins/InputMapper/HidInputMappingForm.cs
+++ b/mediaportal/RemotePlugins/InputMapper/HidInputMappingForm.cs
@@ -929,8 +929,19 @@ namespace MediaPortal.InputDevices
       catch (Exception ex)
       {
         Log.Error(ex);
-        File.Delete(pathCustom);
-        LoadMapping(xmlFile, true);
+        //Force loading defaults if we were not already doing it
+        if (!defaults)
+        {
+          //Possibly corrupted custom configuration
+          //Try loading the defaults then
+          LoadMapping(xmlFile, true);
+        }
+        else
+        {
+          //Loading the default configuration failed
+          //Just propagate our exception then
+          throw ex;
+        }        
       }
     }
 

--- a/mediaportal/RemotePlugins/RemotePlugins.csproj
+++ b/mediaportal/RemotePlugins/RemotePlugins.csproj
@@ -109,7 +109,7 @@
     </Reference>
     <Reference Include="SharpLibHid, Version=1.0.0.0, Culture=neutral, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\Packages\SharpLibHid.1.3.0\lib\net20\SharpLibHid.dll</HintPath>
+      <HintPath>..\..\Packages\SharpLibHid.1.3.1\lib\net20\SharpLibHid.dll</HintPath>
     </Reference>
     <Reference Include="SharpLibWin32">
       <HintPath>..\..\Packages\SharpLibWin32.0.0.7\lib\net20\SharpLibWin32.dll</HintPath>

--- a/mediaportal/RemotePlugins/packages.config
+++ b/mediaportal/RemotePlugins/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SharpLibHid" version="1.3.0" targetFramework="net40" />
+  <package id="SharpLibHid" version="1.3.1" targetFramework="net40" />
   <package id="SharpLibWin32" version="0.0.7" targetFramework="net40" />
 </packages>

--- a/mediaportal/Setup/setup.nsi
+++ b/mediaportal/Setup/setup.nsi
@@ -586,7 +586,7 @@ Section "MediaPortal core files (required)" SecCore
   File "${git_ROOT}\Packages\MediaPortal.TagLib.2.0.3.8\lib\taglib-sharp.dll"
   ; SharpLibHid
   SetOutPath "$MPdir.Base\"
-  File "${git_ROOT}\Packages\SharpLibHid.1.3.0\lib\net20\SharpLibHid.dll"
+  File "${git_ROOT}\Packages\SharpLibHid.1.3.1\lib\net20\SharpLibHid.dll"
   ; SharpLibWin32
   SetOutPath "$MPdir.Base\"
   File "${git_ROOT}\Packages\SharpLibWin32.0.0.7\lib\net20\SharpLibWin32.dll"


### PR DESCRIPTION
Removing volume control actions from HID default configuration.
Adding TvPower, Ext11 and AppCtrlExit as buttons to close MP.
SharpLibHid was updated to enable parsing of TvPower rather than using decimal code.