### PR TITLE
MP1-4804: MiniDisplay breaks volume handler

### DIFF
--- a/mediaportal/Core/Player/VolumeHandler.cs
+++ b/mediaportal/Core/Player/VolumeHandler.cs
@@ -30,6 +30,11 @@ using Action = MediaPortal.GUI.Library.Action;
 
 namespace MediaPortal.Player
 {
+  /// <summary>
+  /// Looks like this class is notably taking care of broadcasting various volume change events.
+  /// This is intended to be used as a singleton.
+  /// The singleton instance should be created from MP main thread.
+  /// </summary>
   public class VolumeHandler
   {
     #region Vars
@@ -112,7 +117,22 @@ namespace MediaPortal.Player
 
     #region Methods
 
-    private static VolumeHandler CreateInstance()
+    /// <summary>
+    /// Create our volume handler singleton.
+    /// </summary>
+    public static void CreateInstance()
+    {
+      if (_instance==null)
+      {
+        _instance = Create();
+      }      
+    }
+
+    /// <summary>
+    /// Create a volume handler.
+    /// </summary>
+    /// <returns>A newly created volume handler.</returns>
+    private static VolumeHandler Create()
     {
       if (GUIGraphicsContext.DeviceAudioConnected > 0)
       {
@@ -389,10 +409,16 @@ namespace MediaPortal.Player
       set { lock (_volumeTable) _volumeTable = value; }
     }
 
+    /// <summary>
+    /// Provide our instance singleton.
+    /// Can be null until explicitly created through CreateInstance.
+    /// </summary>
     public static VolumeHandler Instance
     {
-      get { return _instance ?? (_instance = CreateInstance()); }
+      get { return _instance; }
     }
+
+    
 
     #endregion Properties
 

--- a/mediaportal/MediaPortal.Application/MediaPortal.cs
+++ b/mediaportal/MediaPortal.Application/MediaPortal.cs
@@ -3074,6 +3074,11 @@ public class MediaPortalApp : D3D, IRender
 
     Log.Info("Main: Initializing volume handler");
     #pragma warning disable 168
+    if (VolumeHandler.Instance!=null)
+    {
+      Log.Error("Volume handler already created. Could break volume notifications.");
+    }
+    VolumeHandler.CreateInstance();
     GUIGraphicsContext.VolumeHandler = VolumeHandler.Instance;
     #pragma warning restore 168
 


### PR DESCRIPTION
Creation of the volume handler from the MiniDisplay thread was causing problems.