### PR TITLE
Add Portugal - Vodafone Fiber RF

### DIFF
--- a/TvEngine3/TVLibrary/TVServer.Base/TuningParameters/dvbt/Portugal.Vodafone Fiba RF.xml
+++ b/TvEngine3/TVLibrary/TVServer.Base/TuningParameters/dvbt/Portugal.Vodafone Fiba RF.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ArrayOfDVBTTuning xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <DVBTTuning>
+    <Frequency>626000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>125</Offset>
+  </DVBTTuning>
+  <DVBTTuning>
+    <Frequency>634000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>125</Offset>
+  </DVBTTuning>
+  <DVBTTuning>
+    <Frequency>642000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>125</Offset>
+  </DVBTTuning>
+  <DVBTTuning>
+    <Frequency>650000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>125</Offset>
+  </DVBTTuning>
+  <DVBTTuning>
+    <Frequency>658000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>125</Offset>
+  </DVBTTuning>
+  <DVBTTuning>
+    <Frequency>666000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>125</Offset>
+  </DVBTTuning>
+    <DVBTTuning>
+    <Frequency>674000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>125</Offset>
+  </DVBTTuning>
+</ArrayOfDVBTTuning>


### PR DESCRIPTION
Adds all the current frequencies on Vodafone Portugal.
Channels list: https://www.recursosvdf.pt/ds/docs/rf-canais-frequencias.pdf