### PR TITLE
SharpLibHid.dll would not be copied to output directory...

### DIFF
--- a/mediaportal/MediaPortal.Application/PostBuild.bat
+++ b/mediaportal/MediaPortal.Application/PostBuild.bat
@@ -188,9 +188,6 @@ xcopy %1\..\Packages\MediaPortal-iMON-Display.1.1.0\lib\iMONDisplayWrapper.dll .
 REM taglib-sharp
 xcopy %1\..\Packages\MediaPortal.TagLib.2.1.0.2\lib\net40\taglib-sharp.dll ./Y /D
 
-REM Enable >2GB for 32 bit process
-call %Build%\MSBUILD_MP_LargeAddressAware.bat %2
-
 REM SharpLibHid
 xcopy %1\..\Packages\SharpLibHid.1.4.2\lib\net40\SharpLibHid.dll . /Y /D
 


### PR DESCRIPTION
...preventing use of HID when running from source tree.