### PR TITLE
Sync scheduler thread timer to system clock

### DIFF
--- a/TvEngine3/TVLibrary/TvService/Scheduler/Scheduler.cs
+++ b/TvEngine3/TVLibrary/TvService/Scheduler/Scheduler.cs
@@ -348,7 +348,10 @@ namespace TvService
         bool firstRun = true;
         while (!_evtSchedulerCtrl.WaitOne(1))
         {
-          bool resetTimer = _evtSchedulerWaitCtrl.WaitOne(SCHEDULE_THREADING_TIMER_INTERVAL);
+          // keep scheduler thread timer in sync with system clock for more precise start times
+          DateTime now = DateTime.Now;
+          int SCHEDULE_THREAD_VARIABLE_TIMER = SCHEDULE_THREADING_TIMER_INTERVAL - ((now.Second * 1000) % SCHEDULE_THREADING_TIMER_INTERVAL) - now.Millisecond;
+          bool resetTimer = _evtSchedulerWaitCtrl.WaitOne(SCHEDULE_THREAD_VARIABLE_TIMER);
 
           try
           {


### PR DESCRIPTION
This minor change updates the scheduler timer to match the system clock so that it runs on 00, 15, 30, and 45 second marks of every minute.  This will start the recording process on 00 seconds instead of up to 15 seconds late.