### PR TITLE
Updated tuning parameters for DVB-T UK

### DIFF
--- a/TvEngine3/TVLibrary/TVServer.Base/TuningParameters/dvbt/UK.Angus.xml
+++ b/TvEngine3/TVLibrary/TVServer.Base/TuningParameters/dvbt/UK.Angus.xml
@@ -1,8 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ArrayOfDVBTTuning xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <!-- PSB1 -->
+  <!-- PSB1 [pre-700 18/09/2019] -->
   <DVBTTuning>
     <Frequency>786000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- PSB1 [post-700 18/09/2019] -->
+  <DVBTTuning>
+    <Frequency>570000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>

--- a/TvEngine3/TVLibrary/TVServer.Base/TuningParameters/dvbt/UK.Brougher Mountain.xml
+++ b/TvEngine3/TVLibrary/TVServer.Base/TuningParameters/dvbt/UK.Brougher Mountain.xml
@@ -1,35 +1,60 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ArrayOfDVBTTuning xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <!-- PSB1 [pre-700 04/09/2019] -->
   <DVBTTuning>
     <Frequency>530000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- PSB1 [post-700 04/09/2019] -->
+  <DVBTTuning>
+    <Frequency>538000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- PSB2 [pre-700 04/09/2019] -->
   <DVBTTuning>
     <Frequency>482000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- PSB2 [post-700 04/09/2019] -->
+  <DVBTTuning>
+    <Frequency>554000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- PSB3 [pre-700 04/09/2019] -->
   <DVBTTuning>
     <Frequency>506000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- PSB3 [post-700 04/09/2019] -->
+  <DVBTTuning>
+    <Frequency>602000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- COM4 -->
   <DVBTTuning>
     <Frequency>474000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- COM5 -->
   <DVBTTuning>
     <Frequency>498000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- COM6 -->
   <DVBTTuning>
     <Frequency>522000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- NI Mux -->
   <DVBTTuning>
     <Frequency>546000</Frequency>
     <BandWidth>8</BandWidth>

--- a/TvEngine3/TVLibrary/TVServer.Base/TuningParameters/dvbt/UK.Caldbeck.xml
+++ b/TvEngine3/TVLibrary/TVServer.Base/TuningParameters/dvbt/UK.Caldbeck.xml
@@ -1,57 +1,95 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ArrayOfDVBTTuning xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <!-- PSB1 -->
   <DVBTTuning>
     <Frequency>506000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- PSB2 -->
   <DVBTTuning>
     <Frequency>530000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- PSB3 [pre-700 31/07/2019] -->
   <DVBTTuning>
     <Frequency>546000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- PSB3 [post-700 31/07/2019] -->
+  <DVBTTuning>
+    <Frequency>482000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- COM4 -->
   <DVBTTuning>
     <Frequency>490000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- COM5 -->
   <DVBTTuning>
     <Frequency>514000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- COM6 [pre-700 31/07/2019] -->
   <DVBTTuning>
     <Frequency>538000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- COM6 [post-700 31/07/2019] -->
+  <DVBTTuning>
+    <Frequency>546000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- COM7 [pre-700 31/07/2019] -->
   <DVBTTuning>
     <Frequency>562000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- COM7 [post-700 31/07/2019] Remove -->
+  <!-- COM8 [pre-700 31/07/2019] -->
   <DVBTTuning>
     <Frequency>586000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- COM8 [post-700 31/07/2019] Remove -->
+  <!-- LOC1 [pre-700 31/07/2019] -->
+  <DVBTTuning>
+    <Frequency>754000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- LOC1 [post-700 31/07/2019] -->
+  <!-- PSB1 Scotland -->
   <DVBTTuning>
     <Frequency>522000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- PSB2 Scotland -->
   <DVBTTuning>
     <Frequency>498000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- PSB3 Scotland [pre-700 31/07/2019] -->
   <DVBTTuning>
     <Frequency>482000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- PSB3 Scotland [post-700 31/07/2019] -->
+  <DVBTTuning>
+    <Frequency>474000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>

--- a/TvEngine3/TVLibrary/TVServer.Base/TuningParameters/dvbt/UK.Carmel.xml
+++ b/TvEngine3/TVLibrary/TVServer.Base/TuningParameters/dvbt/UK.Carmel.xml
@@ -1,32 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ArrayOfDVBTTuning xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <!-- PSB1 [pre-700 17/07/2019] -->
   <DVBTTuning>
     <Frequency>786000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- PSB1 [post-700 17/07/2019] -->
+  <DVBTTuning>
+    <Frequency>490000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- PSB2 [pre-700 17/07/2019] -->
   <DVBTTuning>
     <Frequency>730000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- PSB2 [post-700 17/07/2019] -->
+  <DVBTTuning>
+    <Frequency>514000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- PSB3 [pre-700 17/07/2019] -->
   <DVBTTuning>
     <Frequency>762000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- PSB3 [post-700 17/07/2019] -->
+  <DVBTTuning>
+    <Frequency>538000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- COM4 [pre-700 17/07/2019] -->
   <DVBTTuning>
     <Frequency>738000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- COM4 [post-700 17/07/2019] -->
+  <DVBTTuning>
+    <Frequency>570000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- COM5 [pre-700 17/07/2019] -->
   <DVBTTuning>
     <Frequency>770000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- COM5 [post-700 17/07/2019] -->
+  <DVBTTuning>
+    <Frequency>594000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- COM6 [pre-700 17/07/2019] -->
   <DVBTTuning>
     <Frequency>698000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- COM6 [post-700 17/07/2019] -->
+  <DVBTTuning>
+    <Frequency>690000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>

--- a/TvEngine3/TVLibrary/TVServer.Base/TuningParameters/dvbt/UK.Divis.xml
+++ b/TvEngine3/TVLibrary/TVServer.Base/TuningParameters/dvbt/UK.Divis.xml
@@ -1,47 +1,86 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ArrayOfDVBTTuning xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <!-- PSB1 -->
   <DVBTTuning>
     <Frequency>522000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- PSB2 -->
   <DVBTTuning>
     <Frequency>474000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- PSB3 -->
   <DVBTTuning>
     <Frequency>498000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- COM4 -->
   <DVBTTuning>
     <Frequency>490000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- COM5 -->
   <DVBTTuning>
     <Frequency>514000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- COM6 [pre-700 04/09/2019] -->
   <DVBTTuning>
     <Frequency>538000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- COM6 [post-700 04/09/2019] -->
   <DVBTTuning>
     <Frequency>546000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- COM7 [pre-700 04/09/2019] -->
   <DVBTTuning>
     <Frequency>570000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- COM7 [post-700 04/09/2019] -->
+  <DVBTTuning>
+    <Frequency>714000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- COM8 [pre-700 04/09/2019] -->
   <DVBTTuning>
     <Frequency>578000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- COM8 [post-700 04/09/2019] -->
+  <DVBTTuning>
+    <Frequency>786000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- LOC1 [pre-700 04/09/2019] -->
+  <DVBTTuning>
+    <Frequency>546000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- LOC1 [post-700 04/09/2019] -->
+  <DVBTTuning>
+    <Frequency>594000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- NI Mux [post-700 04/09/2019] -->
+  <DVBTTuning>
+    <Frequency>690000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>

--- a/TvEngine3/TVLibrary/TVServer.Base/TuningParameters/dvbt/UK.Dover.xml
+++ b/TvEngine3/TVLibrary/TVServer.Base/TuningParameters/dvbt/UK.Dover.xml
@@ -1,8 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ArrayOfDVBTTuning xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <!-- PSB1 -->
+  <!-- PSB1 [pre-700 22/08/2019] -->
   <DVBTTuning>
     <Frequency>706000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- PSB1 [post-700 21/08/2019] -->
+  <DVBTTuning>
+    <Frequency>570000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>

--- a/TvEngine3/TVLibrary/TVServer.Base/TuningParameters/dvbt/UK.Kilvey Hill.xml
+++ b/TvEngine3/TVLibrary/TVServer.Base/TuningParameters/dvbt/UK.Kilvey Hill.xml
@@ -1,20 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ArrayOfDVBTTuning xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <!-- PSB1 -->
+  <!-- PSB1 [pre-700 17/07/2019] -->
   <DVBTTuning>
     <Frequency>490000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
-  <!-- PSB2 -->
+  <!-- PSB1 [post-700 17/07/2019] -->
+  <DVBTTuning>
+    <Frequency>474000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- PSB2 [pre-700 17/07/2019] -->
   <DVBTTuning>
     <Frequency>514000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
-  <!-- PSB3 -->
+  <!-- PSB2 [post-700 17/07/2019] -->
+  <DVBTTuning>
+    <Frequency>498000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- PSB3 [pre-700 17/07/2019] -->
   <DVBTTuning>
     <Frequency>538000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- PSB3 [post-700 17/07/2019] -->
+  <DVBTTuning>
+    <Frequency>522000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>

--- a/TvEngine3/TVLibrary/TVServer.Base/TuningParameters/dvbt/UK.Limavady.xml
+++ b/TvEngine3/TVLibrary/TVServer.Base/TuningParameters/dvbt/UK.Limavady.xml
@@ -1,32 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ArrayOfDVBTTuning xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <!-- PSB1 [pre-700 04/09/2019] -->
   <DVBTTuning>
     <Frequency>706000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- PSB1 [post-700 04/09/2019] -->
+  <DVBTTuning>
+    <Frequency>634000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- PSB2 [pre-700 04/09/2019] -->
   <DVBTTuning>
     <Frequency>778000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- PSB2 [post-700 04/09/2019] -->
+  <DVBTTuning>
+    <Frequency>658000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- PSB3 [pre-700 04/09/2019] -->
   <DVBTTuning>
     <Frequency>746000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- PSB3 [post-700 04/09/2019] -->
+  <DVBTTuning>
+    <Frequency>682000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- COM4 [pre-700 04/09/2019] -->
   <DVBTTuning>
     <Frequency>738000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- COM4 [post-700 04/09/2019] -->
+  <DVBTTuning>
+    <Frequency>626000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- COM5 [pre-700 04/09/2019] -->
   <DVBTTuning>
     <Frequency>770000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- COM5 [post-700 04/09/2019] -->
+  <DVBTTuning>
+    <Frequency>650000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- COM6 [pre-700 04/09/2019] -->
   <DVBTTuning>
     <Frequency>698000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- COM6 [post-700 04/09/2019] -->
+  <DVBTTuning>
+    <Frequency>674000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>

--- a/TvEngine3/TVLibrary/TVServer.Base/TuningParameters/dvbt/UK.Pontop Pike.xml
+++ b/TvEngine3/TVLibrary/TVServer.Base/TuningParameters/dvbt/UK.Pontop Pike.xml
@@ -1,47 +1,62 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ArrayOfDVBTTuning xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <!-- PSB1 [pre-700 11/09/2019] -->
   <DVBTTuning>
     <Frequency>770000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- PSB1 [post-700 11/09/2019] -->
+  <DVBTTuning>
+    <Frequency>562000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- PSB2 -->
   <DVBTTuning>
     <Frequency>738000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- PSB3 -->
   <DVBTTuning>
     <Frequency>698000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- COM4 -->
   <DVBTTuning>
     <Frequency>706000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- COM5 -->
   <DVBTTuning>
     <Frequency>778000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- COM6 -->
   <DVBTTuning>
     <Frequency>746000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
-  <DVBTTuning>
-    <Frequency>754000</Frequency>
-    <BandWidth>8</BandWidth>
-    <Offset>167</Offset>
-  </DVBTTuning>
+  <!-- COM7 -->
   <DVBTTuning>
     <Frequency>570000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
+  <!-- COM8 -->
   <DVBTTuning>
     <Frequency>578000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- LOC1 -->
+  <DVBTTuning>
+    <Frequency>754000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>

--- a/TvEngine3/TVLibrary/TVServer.Base/TuningParameters/dvbt/UK.Selkirk.xml
+++ b/TvEngine3/TVLibrary/TVServer.Base/TuningParameters/dvbt/UK.Selkirk.xml
@@ -6,33 +6,63 @@
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
-  <!-- PSB2 -->
+  <!-- PSB2 [pre-700 14/08/2019] -->
   <DVBTTuning>
     <Frequency>778000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
-  <!-- PSB3 -->
+  <!-- PSB2 [post-700 14/08/2019] -->
+  <DVBTTuning>
+    <Frequency>578000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- PSB3 [pre-700 14/08/2019] -->
   <DVBTTuning>
     <Frequency>746000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
-  <!-- COM4 -->
+  <!-- PSB3 [post-700 14/08/2019] -->
+  <DVBTTuning>
+    <Frequency>586000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- COM4 [pre-700 14/08/2019] -->
   <DVBTTuning>
     <Frequency>762000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
-  <!-- COM5 -->
+  <!-- COM4 [post-700 14/08/2019] -->
+  <DVBTTuning>
+    <Frequency>570000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- COM5 [pre-700 14/08/2019] -->
   <DVBTTuning>
     <Frequency>730000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>
-  <!-- COM6 -->
+  <!-- COM5 [post-700 14/08/2019] -->
+  <DVBTTuning>
+    <Frequency>594000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- COM6 [pre-700 14/08/2019] -->
   <DVBTTuning>
     <Frequency>786000</Frequency>
+    <BandWidth>8</BandWidth>
+    <Offset>167</Offset>
+  </DVBTTuning>
+  <!-- COM6 [post-700 14/08/2019] -->
+  <DVBTTuning>
+    <Frequency>690000</Frequency>
     <BandWidth>8</BandWidth>
     <Offset>167</Offset>
   </DVBTTuning>


### PR DESCRIPTION
Added the changes published for Q3 2019.

http://www.digitaluk.co.uk/operations/700mhz_clearance/clearance_events_in_2019