### PR TITLE
MP1.38.Final: Fix for MySQL: Retrieval of the RSA public key is not enabled for insecure connections

### DIFF
--- a/TvEngine3/TVLibrary/SetupTv/SetupDatabaseForm.cs
+++ b/TvEngine3/TVLibrary/SetupTv/SetupDatabaseForm.cs
@@ -207,7 +207,7 @@ namespace SetupTv
           if (OSInfo.OSInfo.Win10OrLater() && Utils.Is64bitOS)
           {
             Log.Write("MariaDB / MySQL: Use the new connection string for {0} database.", database);
-            return String.Format("Server={0};Database={3};User ID={1};Password={2};charset=utf8;Connection Timeout={4};commandinterceptors=Gentle.Provider.MySQL.Interceptor.Interceptor,Gentle.Provider.MySQL.Interceptor;SSLMode=Disabled;",
+            return String.Format("Server={0};Database={3};User ID={1};Password={2};charset=utf8;Connection Timeout={4};commandinterceptors=Gentle.Provider.MySQL.Interceptor.Interceptor,Gentle.Provider.MySQL.Interceptor;SSLMode=Disabled;AllowPublicKeyRetrieval=True",
                                  server, userid, password, database, timeout);
           }
           Log.Write("MySQL: Use the old connection string.");


### PR DESCRIPTION
> [!NOTE]
> `AllowPublicKeyRetrieval=True` could allow a malicious proxy to perform a **MITM** attack to get the plaintext password, so it is False by default and must be explicitly enabled.