### PR TITLE
MP1-5268: Change `RMS` and `Spectrum` for audio level meters

### DIFF
--- a/mediaportal/Core/MusicPlayer/BASS/BassAudioEngine.cs
+++ b/mediaportal/Core/MusicPlayer/BASS/BassAudioEngine.cs
@@ -1,6 +1,6 @@
-#region Copyright (C) 2005-2017 Team MediaPortal
+#region Copyright (C) 2005-2026 Team MediaPortal
 
-// Copyright (C) 2005-2017 Team MediaPortal
+// Copyright (C) 2005-2026 Team MediaPortal
 // http://www.team-mediaportal.com
 // 
 // MediaPortal is free software: you can redistribute it and/or modify
@@ -2257,37 +2257,33 @@ namespace MediaPortal.MusicPlayer.BASS
     /// <param name="dbLevelR"></param>
     public void RMS(out double dbLevelL, out double dbLevelR)
     {
-      float[] levels = new float[2];
       dbLevelL = -144.0;
       dbLevelR = -144.0;
 
+      float[] levels = null;
       if (Config.MusicPlayer == AudioPlayer.Asio)
       {
-        float fpeakL = BassAsio.BASS_ASIO_ChannelGetLevel(false, 0);
-        float fpeakR = BassAsio.BASS_ASIO_ChannelGetLevel(false, 1);
-        
-        dbLevelL = fpeakL > 0.00001f ? 20.0 * Math.Log10(fpeakL) : -144.0;
-        dbLevelR = fpeakR > 0.00001f ? 20.0 * Math.Log10(fpeakR) : -144.0;
+        levels = new float[2];
+        levels[0] = BassAsio.BASS_ASIO_ChannelGetLevel(false, 0);
+        levels[1] = BassAsio.BASS_ASIO_ChannelGetLevel(false, 1);
       } 
       else if (Config.MusicPlayer == AudioPlayer.WasApi)
       {
-        if (BassWasapi.BASS_WASAPI_GetLevelEx(levels, 0.05f, BASSLevel.BASS_LEVEL_STEREO | BASSLevel.BASS_LEVEL_RMS))
-        {
-          dbLevelL = levels[0] > 0.00001f ? 20.0 * Math.Log10(levels[0]) : -144.0;
-          dbLevelR = levels[1] > 0.00001f ? 20.0 * Math.Log10(levels[1]) : -144.0;
-        }
+        levels = BassWasapi.BASS_WASAPI_GetLevel(0.05f, BASSLevel.BASS_LEVEL_STEREO | BASSLevel.BASS_LEVEL_RMS);
       }
       else
       {
         MusicStream stream = GetCurrentStream();
         if (stream != null)
         {
-          if (BassMix.BASS_Mixer_ChannelGetLevelEx(stream.BassStream, levels, 0.05f, BASSLevel.BASS_LEVEL_STEREO | BASSLevel.BASS_LEVEL_RMS))
-          {
-            dbLevelL = levels[0] > 0.00001f ? 20.0 * Math.Log10(levels[0]) : -144.0;
-            dbLevelR = levels[1] > 0.00001f ? 20.0 * Math.Log10(levels[1]) : -144.0;
-          }
+          levels = BassMix.BASS_Mixer_ChannelGetLevel(stream.BassStream, 0.05f, BASSLevel.BASS_LEVEL_STEREO | BASSLevel.BASS_LEVEL_RMS);
         }
+      }
+
+      if (levels != null && levels.Length >= 2)
+      {
+        dbLevelL = levels[0] > 0.00001f ? 20.0 * Math.Log10(levels[0]) : dbLevelL;
+        dbLevelR = levels[1] > 0.00001f ? 20.0 * Math.Log10(levels[1]) : dbLevelR;
       }
     }
 

--- a/mediaportal/Core/MusicPlayer/BASS/BassAudioEngine.cs
+++ b/mediaportal/Core/MusicPlayer/BASS/BassAudioEngine.cs
@@ -2316,19 +2316,38 @@ namespace MediaPortal.MusicPlayer.BASS
       }
 
       int _result = -1;
-      float[] _fft = new float[1024];
+      float[] _fft = new float;
+      double sampleRate = 44100.0; // Fallback value
 
       try
       {
         if (Config.MusicPlayer == AudioPlayer.WasApi)
         {
           _result = GetDataFFT(_fft, (int)BASSData.BASS_DATA_FFT2048);
+          if (_result >= 0)
+          {
+            // Fetch info directly from the active WASAPI output device
+            BASS_WASAPI_INFO wasapiInfo = Un4seen.Bass.BassWasapi.BASS_WASAPI_GetInfo();
+            if (wasapiInfo != null)
+            {
+              sampleRate = wasapiInfo.freq; // Gets current WASAPI endpoint rate (e.g., 48000 Hz)
+            }
+          }
         }
         else
         {
           if (_streamcopy != null)
           {
             _result = GetChannelData(_streamcopy.ChannelHandle, _fft, (int)BASSData.BASS_DATA_FFT2048);
+            if (_result >= 0)
+            {
+              // Fetch info directly from the accessible stream copy handle
+              BASS_CHANNELINFO chinfo = Un4seen.Bass.Bass.BASS_ChannelGetInfo(_streamcopy.ChannelHandle);
+              if (chinfo != null)
+              {
+                sampleRate = chinfo.freq; // Automatically gets 44100, 48000, 96000, etc.
+              }
+            }
           }
           else
           {
@@ -2346,85 +2365,66 @@ namespace MediaPortal.MusicPlayer.BASS
         return false;
       }
 
-      int x, y;
-      int b0 = 0;
+      int maxFFTIndex = _fft.Length - 1; // 1023
       bool _needRecalc = (_min != _max && _min != 0 && _max != 255);
 
-      // Calibration constants to align -18 dBFS with 0 VU reference point
-      const double calibrationOffset = 18.0;
-      const double minVU = -45.0; // Lower silence floor (-63 dBFS)
-      const double midVU = -21.0; // Mid-way transition point (-39 dBFS)
-      const double refVU = 0.0;   // Reference 0 VU point (-18 dBFS)
+      // Frequency distribution settings (Standard human hearing range)
+      double minFreq = 20.0;
+      double maxFreq = 20000.0;
 
-      // Computes the spectrum data, the code is taken from a bass_wasapi sample.
-      for (x = 0; x < lines; x++)
+      for (int x = 0; x < lines; x++)
       {
+        // Logarithmic frequency bin distribution
+        double f0 = minFreq * Math.Pow(maxFreq / minFreq, (double)x / lines);
+        double f1 = minFreq * Math.Pow(maxFreq / minFreq, (double)(x + 1) / lines);
+
+        // Map frequencies to FFT array indices using the detected sample rate
+        int b0 = (int)Math.Floor(f0 * 1024.0 / sampleRate);
+        int b1 = (int)Math.Ceiling(f1 * 1024.0 / sampleRate);
+
+        // Ensure indices stay within valid array boundaries
+        b0 = Math.Max(1, Math.Min(b0, maxFFTIndex)); 
+        b1 = Math.Max(b0 + 1, Math.Min(b1, maxFFTIndex));
+
         float peak = 0;
-        int b1 = (int)Math.Pow(2, x * 10.0 / (lines - 1));
-        if (b1 > 1023) 
+        for (int i = b0; i < b1; i++)
         {
-          b1 = 1023;
-        }
-        if (b1 <= b0)
-        {
-          b1 = b0 + 1;
-        }
-        for (; b0 < b1; b0++)
-        {
-          if (peak < _fft[1 + b0]) 
+          if (_fft[i] > peak) 
           {
-            peak = _fft[1 + b0];
+            peak = _fft[i];
           }
         }
 
-        // Convert linear FFT amplitude to dBFS scale.
-        // Add 1e-8 offset to prevent Math.Log10(0) returning NaN in complete silence.
-        double dbfs = 20 * Math.Log10(peak + 1e-8);
+        // Convert linear FFT amplitude to dBFS scale
+        // 1e-5 offset prevents Math.Log10(0) and sets the hard noise floor to -100 dBFS
+        double dbfs = 20 * Math.Log10(peak + 1e-5); 
 
-        // Apply basic calibration (Aligns -18 dBFS to 0 VU / 0 dB)
-        double vuLevel = dbfs + calibrationOffset;
+        // Linear dynamic range scaling
+        // -60 dBFS represents silence (0% height), 0 dBFS represents maximum (100% height)
+        double minDB = -60.0; 
+        double maxDB = 0.0;
 
-        // Non-linear multi-zone compression
-        if (vuLevel > 0.0)
-        {
-          // RED ZONE (vuLevel > 0 VU): 
-          // Re-calibrated so that a 0 dBFS input signal (vuLevel = +18.0) maps precisely to +5.0 VU.
-          double compressedVU = 5.0 * (1.0 - Math.Exp(-vuLevel / 5.43));
-          // Map +0 VU..+5 VU to the upper 25% height range (191..255)
-          double normUpper = compressedVU / 5.0;
-          y = 191 + (int)(normUpper * 64.0);
-        }
-        else
-        {
-          // LOWER ZONE (vuLevel <= 0 VU):
-          // Dual-stage non-linear compression to lift -45 VU towards -21 VU,
-          // while expanding the -21 VU to 0 VU range for high resolution on musical mid-levels.
-          if (vuLevel < minVU) vuLevel = minVU;
-          double normLower;
-          if (vuLevel < midVU)
-          {
-            // Sub-stage A: Deep quiet elements (-45 VU to -21 VU) mapped to 0% - 30% of lower height
-            double segmentFactor = (vuLevel - minVU) / (midVU - minVU);
-            normLower = segmentFactor * 0.3;
-          }
-          else
-          {
-            // Sub-stage B: Active music dynamics (-21 VU to 0 VU) mapped to 30% - 100% of lower height
-            double segmentFactor = (vuLevel - midVU) / (refVU - midVU);
-            normLower = 0.3 + (segmentFactor * 0.7);
-          }
-          // Map the combined non-linear factor to the lower 75% height range (0..191)
-          y = (int)(normLower * 191.0);
-        }
-        y = Math.Max(0, Math.Min(y, 255));
+        if (dbfs < minDB) dbfs = minDB;
+        if (dbfs > maxDB) dbfs = maxDB;
 
+        // Normalize value to 0.0 - 1.0 range
+        double normalized = (dbfs - minDB) / (maxDB - minDB);
+
+        // Gamma correction: Adds beautiful organic bounce to bars and exposes rich mid-to-quiet details
+        normalized = Math.Sqrt(normalized);
+
+        // Map normalized value to base byte range
+        int y = (int)(normalized * 255.0);
+
+        // Recalculate grid mapping
         if (_needRecalc)
         {
-          y = (int)( ( ( (float)y / 255.0 ) * ( (float)_max - (float)_min) ) + (float)_min );
+          y = (int)((((float)y / 255.0f) * ((float)_max - (float)_min)) + (float)_min);
         }
 
-        spectrum[x] = y;
+        spectrum[x] = Math.Max(0, Math.Min(y, 255));
       }
+
       return true;
     }
 

--- a/mediaportal/Core/MusicPlayer/BASS/BassAudioEngine.cs
+++ b/mediaportal/Core/MusicPlayer/BASS/BassAudioEngine.cs
@@ -2412,7 +2412,7 @@ namespace MediaPortal.MusicPlayer.BASS
         normalized = Math.Sqrt(normalized);
 
         // Map normalized value to base byte range
-        int y = (int)(normalized * 255.0);
+        int y = (int)Math.Round(normalized * 255.0);
 
         // Recalculate grid mapping
         if (_needRecalc)

--- a/mediaportal/Core/MusicPlayer/BASS/BassAudioEngine.cs
+++ b/mediaportal/Core/MusicPlayer/BASS/BassAudioEngine.cs
@@ -2257,45 +2257,38 @@ namespace MediaPortal.MusicPlayer.BASS
     /// <param name="dbLevelR"></param>
     public void RMS(out double dbLevelL, out double dbLevelR)
     {
-      int peakL = 0;
-      int peakR = 0;
-      double dbLeft = 0.0;
-      double dbRight = 0.0;
-
-      // Find out with which stream to deal with
-      int level = 0;
+      float[] levels = new float[2];
+      dbLevelL = -144.0;
+      dbLevelR = -144.0;
 
       if (Config.MusicPlayer == AudioPlayer.Asio)
       {
         float fpeakL = BassAsio.BASS_ASIO_ChannelGetLevel(false, 0);
-        float fpeakR = (int)BassAsio.BASS_ASIO_ChannelGetLevel(false, 1);
-        dbLeft = 20.0 * Math.Log10(fpeakL);
-        dbRight = 20.0 * Math.Log10(fpeakR);
-      }
+        float fpeakR = BassAsio.BASS_ASIO_ChannelGetLevel(false, 1);
+        
+        dbLevelL = fpeakL > 0.00001f ? 20.0 * Math.Log10(fpeakL) : -144.0;
+        dbLevelR = fpeakR > 0.00001f ? 20.0 * Math.Log10(fpeakR) : -144.0;
+      } 
       else if (Config.MusicPlayer == AudioPlayer.WasApi)
       {
-        level = BassWasapi.BASS_WASAPI_GetLevel();
+        if (BassWasapi.BASS_WASAPI_GetLevelEx(levels, 0.05f, BASSLevel.BASS_LEVEL_STEREO | BASSLevel.BASS_LEVEL_RMS))
+        {
+          dbLevelL = levels[0] > 0.00001f ? 20.0 * Math.Log10(levels[0]) : -144.0;
+          dbLevelR = levels[1] > 0.00001f ? 20.0 * Math.Log10(levels[1]) : -144.0;
+        }
       }
       else
       {
         MusicStream stream = GetCurrentStream();
         if (stream != null)
         {
-          level = BassMix.BASS_Mixer_ChannelGetLevel(stream.BassStream);
+          if (BassMix.BASS_Mixer_ChannelGetLevelEx(stream.BassStream, levels, 0.05f, BASSLevel.BASS_LEVEL_STEREO | BASSLevel.BASS_LEVEL_RMS))
+          {
+            dbLevelL = levels[0] > 0.00001f ? 20.0 * Math.Log10(levels[0]) : -144.0;
+            dbLevelR = levels[1] > 0.00001f ? 20.0 * Math.Log10(levels[1]) : -144.0;
+          }
         }
       }
-
-      if (Config.MusicPlayer != AudioPlayer.Asio) // For Asio, we already got the peaklevel above
-      {
-        peakL = Un4seen.Bass.Utils.LowWord32(level); // the left level
-        peakR = Un4seen.Bass.Utils.HighWord32(level); // the right level
-
-        dbLeft = Un4seen.Bass.Utils.LevelToDB(peakL, 65535);
-        dbRight = Un4seen.Bass.Utils.LevelToDB(peakR, 65535);
-      }
-
-      dbLevelL = dbLeft;
-      dbLevelR = dbRight;
     }
 
     /// <summary>

--- a/mediaportal/Core/MusicPlayer/BASS/BassAudioEngine.cs
+++ b/mediaportal/Core/MusicPlayer/BASS/BassAudioEngine.cs
@@ -2327,7 +2327,7 @@ namespace MediaPortal.MusicPlayer.BASS
           if (_result >= 0)
           {
             // Fetch info directly from the active WASAPI output device
-            BASS_WASAPI_INFO wasapiInfo = Un4seen.Bass.BassWasapi.BASS_WASAPI_GetInfo();
+            BASS_WASAPI_INFO wasapiInfo = BassWasapi.BASS_WASAPI_GetInfo();
             if (wasapiInfo != null)
             {
               sampleRate = wasapiInfo.freq; // Gets current WASAPI endpoint rate (e.g., 48000 Hz)
@@ -2342,7 +2342,7 @@ namespace MediaPortal.MusicPlayer.BASS
             if (_result >= 0)
             {
               // Fetch info directly from the accessible stream copy handle
-              BASS_CHANNELINFO chinfo = Un4seen.Bass.Bass.BASS_ChannelGetInfo(_streamcopy.ChannelHandle);
+              BASS_CHANNELINFO chinfo = Bass.BASS_ChannelGetInfo(_streamcopy.ChannelHandle);
               if (chinfo != null)
               {
                 sampleRate = chinfo.freq; // Automatically gets 44100, 48000, 96000, etc.
@@ -2365,8 +2365,7 @@ namespace MediaPortal.MusicPlayer.BASS
         return false;
       }
 
-      int maxFFTIndex = _fft.Length - 1; // 1023
-      bool _needRecalc = (_min != _max && _min != 0 && _max != 255);
+      bool _needRecalc = !(_min == 0 && _max == 255) && (_max != _min);
 
       // Frequency distribution settings (Standard human hearing range)
       double minFreq = 20.0;
@@ -2382,9 +2381,8 @@ namespace MediaPortal.MusicPlayer.BASS
         int b0 = (int)Math.Floor(f0 * 1024.0 / sampleRate);
         int b1 = (int)Math.Ceiling(f1 * 1024.0 / sampleRate);
 
-        // Ensure indices stay within valid array boundaries
-        b0 = Math.Max(1, Math.Min(b0, maxFFTIndex)); 
-        b1 = Math.Max(b0 + 1, Math.Min(b1, maxFFTIndex));
+        b0 = Math.Max(1, Math.Min(b0, _fft.Length - 1)); 
+        b1 = Math.Max(b0 + 1, Math.Min(b1, _fft.Length));
 
         float peak = 0;
         for (int i = b0; i < b1; i++)
@@ -2396,8 +2394,8 @@ namespace MediaPortal.MusicPlayer.BASS
         }
 
         // Convert linear FFT amplitude to dBFS scale
-        // 1e-5 offset prevents Math.Log10(0) and sets the hard noise floor to -100 dBFS
-        double dbfs = 20 * Math.Log10(peak + 1e-5); 
+        // 1e-8 offset prevents Math.Log10(0) and sets the hard noise floor to -160 dBFS
+        double dbfs = 20 * Math.Log10(peak + 1e-8); 
 
         // Linear dynamic range scaling
         // -60 dBFS represents silence (0% height), 0 dBFS represents maximum (100% height)

--- a/mediaportal/Core/MusicPlayer/BASS/BassAudioEngine.cs
+++ b/mediaportal/Core/MusicPlayer/BASS/BassAudioEngine.cs
@@ -2316,7 +2316,7 @@ namespace MediaPortal.MusicPlayer.BASS
       }
 
       int _result = -1;
-      float[] _fft = new float;
+      float[] _fft = new float[1024];
 
       try
       {

--- a/mediaportal/Core/MusicPlayer/BASS/BassAudioEngine.cs
+++ b/mediaportal/Core/MusicPlayer/BASS/BassAudioEngine.cs
@@ -2305,7 +2305,8 @@ namespace MediaPortal.MusicPlayer.BASS
       {
         return false;
       }
-      if (lines < 0 || lines > 255)
+      // Prevent division by zero and invalid grid sizes (minimum 2 lines required)
+      if (lines < 2 || lines > 255)
       {
         return false;
       }
@@ -2315,7 +2316,7 @@ namespace MediaPortal.MusicPlayer.BASS
       }
 
       int _result = -1;
-      float[] _fft = new float[1024];
+      float[] _fft = new float;
 
       try
       {
@@ -2342,12 +2343,18 @@ namespace MediaPortal.MusicPlayer.BASS
       }
       if (_result < 0)
       {
-        return false ;
+        return false;
       }
 
       int x, y;
       int b0 = 0;
       bool _needRecalc = (_min != _max && _min != 0 && _max != 255);
+
+      // Calibration constants to align -18 dBFS with 0 VU reference point
+      const double calibrationOffset = 18.0;
+      const double minVU = -45.0; // Lower silence floor (-63 dBFS)
+      const double midVU = -21.0; // Mid-way transition point (-39 dBFS)
+      const double refVU = 0.0;   // Reference 0 VU point (-18 dBFS)
 
       // Computes the spectrum data, the code is taken from a bass_wasapi sample.
       for (x = 0; x < lines; x++)
@@ -2369,16 +2376,48 @@ namespace MediaPortal.MusicPlayer.BASS
             peak = _fft[1 + b0];
           }
         }
-        y = (int)(Math.Sqrt(peak) * 3 * 255 - 4);
 
-        if (y > 255) 
-        { 
-          y = 255;
-        }
-        if (y < 0)
+        // Convert linear FFT amplitude to dBFS scale.
+        // Add 1e-8 offset to prevent Math.Log10(0) returning NaN in complete silence.
+        double dbfs = 20 * Math.Log10(peak + 1e-8);
+
+        // Apply basic calibration (Aligns -18 dBFS to 0 VU / 0 dB)
+        double vuLevel = dbfs + calibrationOffset;
+
+        // Non-linear multi-zone compression
+        if (vuLevel > 0.0)
         {
-           y = 0;
+          // RED ZONE (vuLevel > 0 VU): 
+          // Re-calibrated so that a 0 dBFS input signal (vuLevel = +18.0) maps precisely to +5.0 VU.
+          double compressedVU = 5.0 * (1.0 - Math.Exp(-vuLevel / 5.43));
+          // Map +0 VU..+5 VU to the upper 25% height range (191..255)
+          double normUpper = compressedVU / 5.0;
+          y = 191 + (int)(normUpper * 64.0);
         }
+        else
+        {
+          // LOWER ZONE (vuLevel <= 0 VU):
+          // Dual-stage non-linear compression to lift -45 VU towards -21 VU,
+          // while expanding the -21 VU to 0 VU range for high resolution on musical mid-levels.
+          if (vuLevel < minVU) vuLevel = minVU;
+          double normLower;
+          if (vuLevel < midVU)
+          {
+            // Sub-stage A: Deep quiet elements (-45 VU to -21 VU) mapped to 0% - 30% of lower height
+            double segmentFactor = (vuLevel - minVU) / (midVU - minVU);
+            normLower = segmentFactor * 0.3;
+          }
+          else
+          {
+            // Sub-stage B: Active music dynamics (-21 VU to 0 VU) mapped to 30% - 100% of lower height
+            double segmentFactor = (vuLevel - midVU) / (refVU - midVU);
+            normLower = 0.3 + (segmentFactor * 0.7);
+          }
+          // Map the combined non-linear factor to the lower 75% height range (0..191)
+          y = (int)(normLower * 191.0);
+        }
+        y = Math.Max(0, Math.Min(y, 255));
+
         if (_needRecalc)
         {
           y = (int)( ( ( (float)y / 255.0 ) * ( (float)_max - (float)_min) ) + (float)_min );

--- a/mediaportal/Core/MusicPlayer/BASS/BassAudioEngine.cs
+++ b/mediaportal/Core/MusicPlayer/BASS/BassAudioEngine.cs
@@ -2316,7 +2316,7 @@ namespace MediaPortal.MusicPlayer.BASS
       }
 
       int _result = -1;
-      float[] _fft = new float;
+      float[] _fft = new float[1024];
       double sampleRate = 44100.0; // Fallback value
 
       try

--- a/mediaportal/Core/MusicPlayer/BASS/BassAudioEngine.cs
+++ b/mediaportal/Core/MusicPlayer/BASS/BassAudioEngine.cs
@@ -2399,8 +2399,8 @@ namespace MediaPortal.MusicPlayer.BASS
 
         // Linear dynamic range scaling
         // -60 dBFS represents silence (0% height), 0 dBFS represents maximum (100% height)
-        double minDB = -60.0; 
-        double maxDB = 0.0;
+        double minDB = -60.0;
+        double maxDB = -0.5; // Shifted slightly from 0.0 to compensate for spectral leakage
 
         if (dbfs < minDB) dbfs = minDB;
         if (dbfs > maxDB) dbfs = maxDB;
@@ -2411,16 +2411,17 @@ namespace MediaPortal.MusicPlayer.BASS
         // Gamma correction: Adds beautiful organic bounce to bars and exposes rich mid-to-quiet details
         normalized = Math.Sqrt(normalized);
 
-        // Map normalized value to base byte range
-        int y = (int)Math.Round(normalized * 255.0);
+        // Map normalized value to the active canvas coordinate grid
+        float rawHeight = _needRecalc ? ((float)normalized * (_max - _min)) + _min : (float)normalized * 255.0f;
 
-        // Recalculate grid mapping
-        if (_needRecalc)
-        {
-          y = (int)((((float)y / 255.0f) * ((float)_max - (float)_min)) + (float)_min);
-        }
+        // Apply a single atomic round operation to avoid precision loss on peak levels
+        int barHeight = (int)Math.Round(rawHeight);
 
-        spectrum[x] = Math.Max(0, Math.Min(y, 255));
+        // Clamp the final value safely within the resolved grid boundaries
+        int clampMin = _needRecalc ? Math.Min(_min, _max) : 0;
+        int clampMax = _needRecalc ? Math.Max(_min, _max) : 255;
+
+        spectrum[x] = Math.Max(clampMin, Math.Min(barHeight, clampMax));
       }
 
       return true;

--- a/mediaportal/WindowPlugins/Common.GUIPlugins/Music/GUIMusicPlayingNow.cs
+++ b/mediaportal/WindowPlugins/Common.GUIPlugins/Music/GUIMusicPlayingNow.cs
@@ -718,11 +718,25 @@ namespace MediaPortal.GUI.Music
         BassMusicPlayer.Player.RMS(out double dbfsL, out double dbfsR);
 
         // Calibration: Shift the digital scale so that -18 dBFS aligns with 0 VU reference point.
-        const double calibrationOffset = 18.0; 
+        // Additionally adds +3.01 dB (AES-17) to compensate for the Peak-to-RMS difference of a sine wave.
+        const double calibrationOffset = 21.01; 
         double vuLevelL = dbfsL + calibrationOffset;
         double vuLevelR = dbfsR + calibrationOffset;
 
         // Log.Debug("VU Meter Levels (VU Scale): L={0:F2} dB | R={1:F2} dB", vuLevelL, vuLevelR);
+
+        // Non-linear compression for the positive zone (+0VU to +3VU)
+        // If the signal goes above 0VU, we softly compress it so it fits within the +3VU maximum texture limit.
+        if (vuLevelL > 0.0)
+        {
+          // Math.Exp function flattens the curve. 
+          // Even at +16dBFS over-level, it smoothly scales down to +3VU
+          vuLevelL = 3.0 * (1.0 - Math.Exp(-vuLevelL / 9.0));
+        }
+        if (vuLevelR > 0.0)
+        {
+          vuLevelR = 3.0 * (1.0 - Math.Exp(-vuLevelR / 9.0));
+        }
 
         // Resolve the texture names according to the calibrated VU scale
         string fileL = GetVUTextureName(vuLevelL);

--- a/mediaportal/WindowPlugins/Common.GUIPlugins/Music/GUIMusicPlayingNow.cs
+++ b/mediaportal/WindowPlugins/Common.GUIPlugins/Music/GUIMusicPlayingNow.cs
@@ -1,6 +1,6 @@
-#region Copyright (C) 2005-2017 Team MediaPortal
+#region Copyright (C) 2005-2026 Team MediaPortal
 
-// Copyright (C) 2005-2017 Team MediaPortal
+// Copyright (C) 2005-2026 Team MediaPortal
 // http://www.team-mediaportal.com
 // 
 // MediaPortal is free software: you can redistribute it and/or modify
@@ -720,10 +720,10 @@ namespace MediaPortal.GUI.Music
         BassMusicPlayer.Player.RMS(out dbLevelL, out dbLevelR);
 
         // Raise the level with factor 1.5 so that the VUMeter shows more activity
-        dbLevelL += Math.Abs(dbLevelL*0.5);
-        dbLevelR += Math.Abs(dbLevelR*0.5);
+        dbLevelL += Math.Abs(dbLevelL * 0.5);
+        dbLevelR += Math.Abs(dbLevelR * 0.5);
 
-        //Console.WriteLine("{0} {1}",(int)dbLevelL, (int)dbLevelR);
+        Log.Debug("OnVUMterTimerTickEvent: {0} - {1} | {2} - {3}", (int)dbLevelL, (int)dbLevelR, dbLevelL, dbLevelR);
 
         string file = "VU1.png";
         if ((int) dbLevelL < -15)

--- a/mediaportal/WindowPlugins/Common.GUIPlugins/Music/GUIMusicPlayingNow.cs
+++ b/mediaportal/WindowPlugins/Common.GUIPlugins/Music/GUIMusicPlayingNow.cs
@@ -730,7 +730,7 @@ namespace MediaPortal.GUI.Music
         if (vuLevelL > 0.0)
         {
           // Math.Exp function flattens the curve. 
-          // Even at +16dBFS over-level, it smoothly scales down to +3VU
+          // Even at +16VU over-level, it smoothly scales down to +3VU
           vuLevelL = 3.0 * (1.0 - Math.Exp(-vuLevelL / 9.0));
         }
         if (vuLevelR > 0.0)

--- a/mediaportal/WindowPlugins/Common.GUIPlugins/Music/GUIMusicPlayingNow.cs
+++ b/mediaportal/WindowPlugins/Common.GUIPlugins/Music/GUIMusicPlayingNow.cs
@@ -713,146 +713,51 @@ namespace MediaPortal.GUI.Music
     /// <param name="e"></param>
     private void OnVUMterTimerTickEvent(object sender, ElapsedEventArgs e)
     {
-      double dbLevelL = 0.0;
-      double dbLevelR = 0.0;
       if (BassAudioEngine._initialized)
       {
-        BassMusicPlayer.Player.RMS(out dbLevelL, out dbLevelR);
+        BassMusicPlayer.Player.RMS(out double dbfsL, out double dbfsR);
 
-        // Raise the level with factor 1.5 so that the VUMeter shows more activity
-        dbLevelL += Math.Abs(dbLevelL * 0.5);
-        dbLevelR += Math.Abs(dbLevelR * 0.5);
+        // Calibration: Shift the digital scale so that -18 dBFS aligns with 0 VU reference point.
+        // Adjusted from 18.0 to 21.0 to compensate for the -3 dB attenuation introduced by the BASS core routing.
+        const double calibrationOffset = 21.0; 
+        double vuLevelL = dbfsL + calibrationOffset;
+        double vuLevelR = dbfsR + calibrationOffset;
 
-        Log.Debug("OnVUMterTimerTickEvent: {0} - {1} | {2} - {3}", (int)dbLevelL, (int)dbLevelR, dbLevelL, dbLevelR);
+        // Log.Debug("VU Meter Levels (VU Scale): L={0:F2} dB | R={1:F2} dB", vuLevelL, vuLevelR);
 
-        string file = "VU1.png";
-        if ((int) dbLevelL < -15)
-        {
-          file = "VU1.png";
-        }
-        else if ((int) dbLevelL < -10)
-        {
-          file = "VU2.png";
-        }
-        else if ((int) dbLevelL < -8)
-        {
-          file = "VU3.png";
-        }
-        else if ((int) dbLevelL < -7)
-        {
-          file = "VU4.png";
-        }
-        else if ((int) dbLevelL < -6)
-        {
-          file = "VU5.png";
-        }
-        else if ((int) dbLevelL < -5)
-        {
-          file = "VU6.png";
-        }
-        else if ((int) dbLevelL < -4)
-        {
-          file = "VU7.png";
-        }
-        else if ((int) dbLevelL < -3)
-        {
-          file = "VU8.png";
-        }
-        else if ((int) dbLevelL < -2)
-        {
-          file = "VU9.png";
-        }
-        else if ((int) dbLevelL < -1)
-        {
-          file = "VU10.png";
-        }
-        else if ((int) dbLevelL < 0)
-        {
-          file = "VU11.png";
-        }
-        else if ((int) dbLevelL < 1)
-        {
-          file = "VU12.png";
-        }
-        else if ((int) dbLevelL < 2)
-        {
-          file = "VU13.png";
-        }
-        else if ((int) dbLevelL < 3)
-        {
-          file = "VU14.png";
-        }
-        else
-        {
-          file = "VU15.png";
-        }
-        // GUIPropertyManager.SetProperty("#VUMeterL", Path.Combine(VUMeterLeft.ImagePath, file));
-        GUIPropertyManager.SetProperty("#VUMeterL", file);
+        // Resolve the texture names according to the calibrated VU scale
+        string fileL = GetVUTextureName(vuLevelL);
+        string fileR = GetVUTextureName(vuLevelR);
 
-        if ((int) dbLevelR < -15)
-        {
-          file = "VU1.png";
-        }
-        else if ((int) dbLevelR < -10)
-        {
-          file = "VU2.png";
-        }
-        else if ((int) dbLevelR < -8)
-        {
-          file = "VU3.png";
-        }
-        else if ((int) dbLevelR < -7)
-        {
-          file = "VU4.png";
-        }
-        else if ((int) dbLevelR < -6)
-        {
-          file = "VU5.png";
-        }
-        else if ((int) dbLevelR < -5)
-        {
-          file = "VU6.png";
-        }
-        else if ((int) dbLevelR < -4)
-        {
-          file = "VU7.png";
-        }
-        else if ((int) dbLevelR < -3)
-        {
-          file = "VU8.png";
-        }
-        else if ((int) dbLevelR < -2)
-        {
-          file = "VU9.png";
-        }
-        else if ((int) dbLevelR < -1)
-        {
-          file = "VU10.png";
-        }
-        else if ((int) dbLevelR < 0)
-        {
-          file = "VU11.png";
-        }
-        else if ((int) dbLevelR < 1)
-        {
-          file = "VU12.png";
-        }
-        else if ((int) dbLevelR < 2)
-        {
-          file = "VU13.png";
-        }
-        else if ((int) dbLevelR < 3)
-        {
-          file = "VU14.png";
-        }
-        else
-        {
-          file = "VU15.png";
-        }
-        // GUIPropertyManager.SetProperty("#VUMeterR", Path.Combine(VUMeterRight.ImagePath, file));
-        GUIPropertyManager.SetProperty("#VUMeterR", file);
+        GUIPropertyManager.SetProperty("#VUMeterL", fileL);
+        GUIPropertyManager.SetProperty("#VUMeterR", fileR);
       }
     }
+
+    /// <summary>
+    /// Maps calibrated VU decibel values directly to the non-linear analog meter texture slots.
+    /// </summary>
+    private string GetVUTextureName(double vuLevel)
+    {
+      // Exact mapping based on the visual layout of your 15-frame VU meter
+      if (vuLevel <= -15.0) return "VU1.png";  // -20 VU (Minimum resting point)
+      if (vuLevel <= -11.0) return "VU2.png";  // Approach to -10 VU
+      if (vuLevel <= -9.0) return "VU3.png";   // -10 VU
+      if (vuLevel <= -7.5) return "VU4.png";   // Between -10 and -7 VU
+      if (vuLevel <= -6.5) return "VU5.png";   // -8 VU
+      if (vuLevel <= -5.5) return "VU6.png";   // -7 VU
+      if (vuLevel <= -4.5) return "VU7.png";   // -5 VU
+      if (vuLevel <= -3.5) return "VU8.png";   // -4 VU
+      if (vuLevel <= -2.5) return "VU9.png";   // -3 VU
+      if (vuLevel <= -1.5) return "VU10.png";  // -2 VU
+      if (vuLevel <= -0.5) return "VU11.png";  // -1 VU
+      if (vuLevel <= 0.5) return "VU12.png";   //  0 VU (Reference Zero Point)
+      if (vuLevel <= 1.5) return "VU13.png";   // +1 VU
+      if (vuLevel <= 2.5) return "VU14.png";   // +2 VU
+
+      return "VU15.png";                       // +3 VU (Scale Maximum / Red Zone)
+    }
+
 
     private void UpdateImagePathContainer()
     {

--- a/mediaportal/WindowPlugins/Common.GUIPlugins/Music/GUIMusicPlayingNow.cs
+++ b/mediaportal/WindowPlugins/Common.GUIPlugins/Music/GUIMusicPlayingNow.cs
@@ -123,6 +123,8 @@ namespace MediaPortal.GUI.Music
     private static readonly Random Randomizer = new Random();
     private bool _lookupSimilarTracks;
     private bool _isStopped = false;
+    private double _smoothLevelL = -15.0;
+    private double _smoothLevelR = -15.0;
 
     #endregion
 
@@ -512,7 +514,7 @@ namespace MediaPortal.GUI.Music
           _vuMeter.ToLowerInvariant() != "none")
       {
         VUMeterTimer = new Timer();
-        VUMeterTimer.Interval = 10;
+        VUMeterTimer.Interval = 30;
         VUMeterTimer.Elapsed += new ElapsedEventHandler(OnVUMterTimerTickEvent);
         VUMeterTimer.Start();
       }
@@ -738,9 +740,18 @@ namespace MediaPortal.GUI.Music
           vuLevelR = 3.0 * (1.0 - Math.Exp(-vuLevelR / 9.0));
         }
 
+        // Ballistics: Smooth needle decay
+        // 1.0 means instant movement (for attack), 0.18 means smooth falling (for decay)
+        // Adjusted specifically for a 30ms timer interval to mimic IEC 60268-17 standard.
+        double coefL = (vuLevelL > _smoothLevelL) ? 1.0 : 0.13;
+        _smoothLevelL += (vuLevelL - _smoothLevelL) * coefL;
+
+        double coefR = (vuLevelR > _smoothLevelR) ? 1.0 : 0.13;
+        _smoothLevelR += (vuLevelR - _smoothLevelR) * coefR;
+
         // Resolve the texture names according to the calibrated VU scale
-        string fileL = GetVUTextureName(vuLevelL);
-        string fileR = GetVUTextureName(vuLevelR);
+        string fileL = GetVUTextureName(_smoothLevelL);
+        string fileR = GetVUTextureName(_smoothLevelR);
 
         GUIPropertyManager.SetProperty("#VUMeterL", fileL);
         GUIPropertyManager.SetProperty("#VUMeterR", fileR);

--- a/mediaportal/WindowPlugins/Common.GUIPlugins/Music/GUIMusicPlayingNow.cs
+++ b/mediaportal/WindowPlugins/Common.GUIPlugins/Music/GUIMusicPlayingNow.cs
@@ -718,8 +718,7 @@ namespace MediaPortal.GUI.Music
         BassMusicPlayer.Player.RMS(out double dbfsL, out double dbfsR);
 
         // Calibration: Shift the digital scale so that -18 dBFS aligns with 0 VU reference point.
-        // Adjusted from 18.0 to 21.0 to compensate for the -3 dB attenuation introduced by the BASS core routing.
-        const double calibrationOffset = 21.0; 
+        const double calibrationOffset = 18.0; 
         double vuLevelL = dbfsL + calibrationOffset;
         double vuLevelR = dbfsR + calibrationOffset;
 

--- a/mediaportal/WindowPlugins/Common.GUIPlugins/Music/GUIMusicPlayingNow.cs
+++ b/mediaportal/WindowPlugins/Common.GUIPlugins/Music/GUIMusicPlayingNow.cs
@@ -727,17 +727,32 @@ namespace MediaPortal.GUI.Music
 
         // Log.Debug("VU Meter Levels (VU Scale): L={0:F2} dB | R={1:F2} dB", vuLevelL, vuLevelR);
 
-        // Non-linear compression for the positive zone (+0VU to +3VU)
-        // If the signal goes above 0VU, we softly compress it so it fits within the +3VU maximum texture limit.
+        // Left channel non-linear compression and expansion
         if (vuLevelL > 0.0)
         {
-          // Math.Exp function flattens the curve. 
-          // Even at +16VU over-level, it smoothly scales down to +3VU
+          // Positive zone (+0VU to +3VU): Softly flattens over-levels towards +3VU limit.
+          // The Math.Exp function flattens the curve, smoothly scaling down even a +16VU spike.
           vuLevelL = 3.0 * (1.0 - Math.Exp(-vuLevelL / 9.0));
         }
+        else
+        {
+          // Negative zone (-45VU up to 0VU): Non-linear expansion that safely lifts -45VU up to -20VU.
+          // 1.083 is the mathematically calculated denominator to ensure that an input of -45VU results exactly in -20VU.
+          if (vuLevelL < -45.0) vuLevelL = -45.0;
+          vuLevelL = -20.0 * (1.0 - Math.Exp(vuLevelL / 1.083)) / (1.0 - Math.Exp(-45.0 / 1.083));
+        }
+
+        // Right channel non-linear compression and expansion
         if (vuLevelR > 0.0)
         {
+          // Positive zone (+0VU to +3VU): Softly flattens over-levels towards +3VU limit.
           vuLevelR = 3.0 * (1.0 - Math.Exp(-vuLevelR / 9.0));
+        }
+        else
+        {
+          // Negative zone (-45VU up to 0VU): Non-linear expansion that safely lifts -45VU up to -20VU.
+          if (vuLevelR < -45.0) vuLevelR = -45.0;
+          vuLevelR = -20.0 * (1.0 - Math.Exp(vuLevelR / 1.083)) / (1.0 - Math.Exp(-45.0 / 1.083));
         }
 
         // Ballistics: Smooth needle decay

--- a/mediaportal/WindowPlugins/Common.GUIPlugins/Music/GUIMusicPlayingNow.cs
+++ b/mediaportal/WindowPlugins/Common.GUIPlugins/Music/GUIMusicPlayingNow.cs
@@ -736,10 +736,12 @@ namespace MediaPortal.GUI.Music
         }
         else
         {
-          // Negative zone (-45VU up to 0VU): Non-linear expansion that safely lifts -45VU up to -20VU.
-          // 1.083 is the mathematically calculated denominator to ensure that an input of -45VU results exactly in -20VU.
+          // Negative zone (-45VU up to 0VU): Smoothly scales down towards -20VU.
           if (vuLevelL < -45.0) vuLevelL = -45.0;
-          vuLevelL = -20.0 * (1.0 - Math.Exp(vuLevelL / 1.083)) / (1.0 - Math.Exp(-45.0 / 1.083));
+          // Scale the dynamic range so that -45 VU of silence maps smoothly to your lowest texture (-20 VU).
+          // Using a tuning factor of 15.0 allows the needle to decay linearly and spend more time 
+          // in the active musical zones (-3 to -15 VU), rather than dropping like a stone.
+          vuLevelL = -20.0 * (1.0 - Math.Exp(vuLevelL / 15.0)) / (1.0 - Math.Exp(-45.0 / 15.0));          
         }
 
         // Right channel non-linear compression and expansion
@@ -750,9 +752,12 @@ namespace MediaPortal.GUI.Music
         }
         else
         {
-          // Negative zone (-45VU up to 0VU): Non-linear expansion that safely lifts -45VU up to -20VU.
+          // Negative zone (-45VU up to 0VU): Smoothly scales down towards -20VU.
           if (vuLevelR < -45.0) vuLevelR = -45.0;
-          vuLevelR = -20.0 * (1.0 - Math.Exp(vuLevelR / 1.083)) / (1.0 - Math.Exp(-45.0 / 1.083));
+          // Scale the dynamic range so that -45 VU of silence maps smoothly to your lowest texture (-20 VU).
+          // Using a tuning factor of 15.0 allows the needle to decay linearly and spend more time 
+          // in the active musical zones (-3 to -15 VU), rather than dropping like a stone.
+          vuLevelR = -20.0 * (1.0 - Math.Exp(vuLevelR / 15.0)) / (1.0 - Math.Exp(-45.0 / 15.0));          
         }
 
         // Ballistics: Smooth needle decay


### PR DESCRIPTION
### Summary of Changes
This pull request overhauls the calculation physics and visualization dynamics for both the VU meters (RMS) and the frequency spectrum analyzer inside the BASS audio engine module. It eliminates previous constraints where levels would either clip prematurely or drop abruptly, providing a highly precise, responsive, and organically bouncing visual response that perfectly mimics professional analog audio hardware (e.g., TEAC style analysis meters).

### Key Features and Bug Fixes

#### 1. Universal Spectrum Analyzer Overhaul (`GetSpectrum`)
* **Dynamic Sample Rate Detection:** Replaced fixed fallback assumptions with real-time hardware clock polling via `BASS_WASAPI_GetInfo()` and `BASS_ChannelGetInfo()` to correctly map frequencies across 44.1kHz, 48kHz, and high-res streams.
* **Logarithmic Bin Distribution:** Fixed the sub-bass "blindness" by implementing an exact log-scale allocation from 20 Hz to 20,000 Hz, ensuring rich low-end activity on screen.
* **Independent Pure dBFS Scaling:** Shifted spectrum scaling away from the RMS-biased offset, running it on an autonomous -60 dBFS to 0 dBFS range with a deep -160 dBFS numerical floor (offset `1e-8`). This prevents any micro-chatter from the Windows mixer in complete silence.
* **Gamma Correction & Visual Coverage:** Integrated a non-linear `Math.Sqrt` gamma filter to expose quiet-to-mid musical nuances. Switched integer conversion to `Math.Round` to eliminate truncation loss and guarantee full vertical texture element coverage at 0 dBFS.

#### 2. Advanced VU Meter Ballistics (`OnVUMterTimerTickEvent`)
* **AES-17 Calibration Alignment:** Anchored digital references to ensure a clear nominal 0 VU alignment with -18 dBFS.
* **Dual-Stage Non-Linear Compression:** Retained the soft exponential compression for the positive over-level zone (+0 VU to +3 VU) to maintain peak definition without flatlining.
* **Smooth Expander Negative Zone:** Replaced the steep linear fall-off in the sub-zero zone (-45 VU to 0 VU) with an expanded curve based on a tuned 15.0 coefficient. The needle/LED segment decay now glides smoothly through intermediate texture indexes instead of dropping instantly like a stone.

---

### Verification and Testing
Extensively verified utilizing professional calibrated laboratory test records (ranging incrementally from `0 dB` down to `-60 dB` at `1001 Hz` signals):
* **The Spectrum Analyzer** now accurately extracts single-bin frequency points, perfectly mapping the peak output to the maximum vertical limit while safely holding unallocated bars to a completely static background floor layout.
* **The VU Meters** fully utilize the 15-frame texture layout without skipping assets, gracefully handling ballistic decay to the resting frame during audio pauses.
